### PR TITLE
Deprecate Falsey

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -18,7 +18,48 @@ require('kind-of', 'typeOf');
 // matching utils
 require('is-glob');
 require('micromatch', 'mm');
-require('falsey');
+utils.falsey = function falsey(val, keywords) {
+    if (!val) {
+      return true;
+    }
+  
+    let words = keywords || [
+      "0",
+      "false",
+      "nada",
+      "nil",
+      "nay",
+      "nah",
+      "negative",
+      "no",
+      "none",
+      "nope",
+      "nul",
+      "null",
+      "nix",
+      "nyet",
+      "uh-uh",
+      "veto",
+      "zero",
+    ];
+  
+    if (!Array.isArray(words)) {
+      words = [words];
+    }
+  
+    const lower = typeof val === "string" ? val.toLowerCase() : null;
+  
+    for (const word of words) {
+      if (word === val) {
+        return true;
+      }
+      if (word === lower) {
+        return true;
+      }
+    }
+  
+    return false;
+  };
 
 // Number utils
 require('is-even');

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "define-property": "^2.0.2",
     "ent": "^2.2.1",
     "extend-shallow": "^3.0.2",
-    "falsey": "^1.0.0",
     "for-in": "^1.0.2",
     "for-own": "^1.0.0",
     "fs-exists-sync": "^0.1.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Followed the [Contributing](https://github.com/jaredwray/fumanchu/blob/main/CONTRIBUTING.md) guidelines.
- [X] Tests for the changes have been added (for bug fixes/features) without decreasing code coverage.
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix to deprecate/replace the `falsey` package which appears to be unmaintained (last publish 6 years ago): https://www.npmjs.com/package/falsey

Addresses [this](https://github.com/jonschlinkert/falsey/issues/9) issue where the falsey package is trying to reassign a constant.

All `fumanchu` builds fail to compile with the existing package:

![image](https://github.com/jaredwray/fumanchu/assets/12202407/e1da4939-89ea-467c-b6ad-2f50ebb05ddf)
