### PR TITLE
feat: migrate array helpers to TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Handlebars + Helpers Together
 # Usage Nodejs
 
 ```bash
-npm install @jaredwray/fumanchu --save
+pnpm add @jaredwray/fumanchu
 ```
 
 ```javascript
@@ -102,9 +102,9 @@ console.log(html); // <p>Foo is bar</p>
 ```
 
 ## How to Contribute
-clone the repository locally and run 'npm i' in the root. Now that you've set up your workspace, you're ready to contribute changes to the `fumanchu` repository you can refer to the [CONTRIBUTING](CONTRIBUTING.md) guide. If you have any questions please feel free to ask by creating an issue and label it `question`.
+clone the repository locally and run 'pnpm i' in the root. Now that you've set up your workspace, you're ready to contribute changes to the `fumanchu` repository you can refer to the [CONTRIBUTING](CONTRIBUTING.md) guide. If you have any questions please feel free to ask by creating an issue and label it `question`.
 
-To test the legacy helpers, you can run `npm run test:legacy` to run the tests. If you want to test the new helpers, you can run `npm run test`.
+To test the legacy helpers, you can run `pnpm run test:legacy` to run the tests. If you want to test the new helpers, you can run `pnpm test`.
 
 ## License and Copyright
 [MIT](LICENSE) and codebase after 2023 will be copyright of Jared Wray.

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "test": "xo --fix && vitest run --coverage",
     "test:ci": "xo && vitest run --coverage",
-    "test:all": "npm run test && npm run test:legacy",
-    "test:legacy": "npm run build && c8 mocha",
-    "test:legacy:ci": "npm run build && c8 --reporter=lcov mocha",
+    "test:all": "pnpm run test && pnpm run test:legacy",
+    "test:legacy": "pnpm run build && c8 mocha",
+    "test:legacy:ci": "pnpm run build && c8 --reporter=lcov mocha",
     "build": "rimraf ./dist && tsup ./src/index.ts --format cjs --dts --clean",
-    "prepare": "npm run build",
+    "prepare": "pnpm run build",
     "clean": "rimraf ./node_modules ./coverage yarn.lock package-lock.json ./dist ./dist-site",
     "website:build": "rimraf ./site/readme.md && npx -y docula build -s ./site -o ./dist-site",
     "website:serve": "rimraf ./site/readme.md && npx -y docula serve -s ./site -o ./dist-site"

--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -26,12 +26,12 @@ export class HelperRegistry {
 		this.init();
 	}
 
-        public init() {
-                // Date
-                this.registerHelpers(dateHelpers);
-                // Array
-                this.registerHelpers(arrayHelpers);
-        }
+	public init() {
+		// Date
+		this.registerHelpers(dateHelpers);
+		// Array
+		this.registerHelpers(arrayHelpers);
+	}
 
 	public register(helper: Helper): boolean {
 		const result = false;

--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -1,4 +1,5 @@
 import {helpers as dateHelpers} from './helpers/date.js';
+import {helpers as arrayHelpers} from './helpers/array.js';
 
 export enum HelperRegistryCompatibility {
 	NODEJS = 'nodejs',
@@ -25,10 +26,12 @@ export class HelperRegistry {
 		this.init();
 	}
 
-	public init() {
-		// Date
-		this.registerHelpers(dateHelpers);
-	}
+        public init() {
+                // Date
+                this.registerHelpers(dateHelpers);
+                // Array
+                this.registerHelpers(arrayHelpers);
+        }
 
 	public register(helper: Helper): boolean {
 		const result = false;

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -1,0 +1,330 @@
+import {type Helper} from '../helper-registry.js';
+
+// Utility helpers
+const isNumber = (value: unknown): value is number => {
+        if (typeof value === 'number') {
+                return !Number.isNaN(value);
+        }
+        if (typeof value === 'string' && value.trim() !== '') {
+                return !Number.isNaN(Number(value));
+        }
+        return false;
+};
+
+const get = (obj: any, path: string): any => {
+        if (!obj || typeof path !== 'string') {
+                return undefined;
+        }
+        return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+};
+
+const after = (array: any[], n: number): any[] => {
+        if (!Array.isArray(array)) return [];
+        return array.slice(n);
+};
+
+const arrayify = (value: any): any[] => {
+        return value ? (Array.isArray(value) ? value : [value]) : [];
+};
+
+const before = (array: any[], n: number): any[] => {
+        if (!Array.isArray(array)) return [];
+        return array.slice(0, -n);
+};
+
+const eachIndex = (array: any[], options: any): string => {
+        if (!Array.isArray(array)) return '';
+        let result = '';
+        for (let i = 0; i < array.length; i++) {
+                result += options.fn({item: array[i], index: i});
+        }
+        return result;
+};
+
+interface FilterHash { property?: string; prop?: string; }
+const filter = (array: any[], value: any, options: any): string => {
+        if (!Array.isArray(array)) return options.inverse(this);
+        const hash: FilterHash = options.hash || {};
+        const prop = hash.property || hash.prop;
+        const results = prop
+                ? array.filter((val) => value === get(val, prop))
+                : array.filter((v) => value === v);
+        if (results.length > 0) {
+                return results.map((r: any) => options.fn(r)).join('');
+        }
+        return options.inverse(this);
+};
+
+const first = (array: any[], n?: number): any => {
+        if (!Array.isArray(array)) return '';
+        if (!isNumber(n)) {
+                return array[0];
+        }
+        return array.slice(0, n);
+};
+
+const forEach = (array: any[], options: any): string => {
+        if (!Array.isArray(array)) return '';
+        const len = array.length;
+        let buffer = '';
+        for (let i = 0; i < len; i++) {
+                const item = array[i];
+                const data = {
+                        index: i,
+                };
+                item.index = i + 1;
+                item.total = len;
+                item.isFirst = i === 0;
+                item.isLast = i === len - 1;
+                buffer += options.fn(item, {data});
+        }
+        return buffer;
+};
+
+const inArray = (array: any[], value: any, options: any): any => {
+        const found = Array.isArray(array) && array.indexOf(value) > -1;
+        if (options && typeof options.fn === 'function') {
+                return found ? options.fn(this) : options.inverse(this);
+        }
+        return found;
+};
+
+const isArray = (value: any): boolean => Array.isArray(value);
+
+const itemAt = (array: any[], idx?: number): any => {
+        if (!Array.isArray(array)) return null;
+        const i = isNumber(idx) ? Number(idx) : 0;
+        if (i < 0) {
+                return array[array.length + i];
+        }
+        return array[i];
+};
+
+const join = (array: any[] | string, separator?: string): string => {
+        if (typeof array === 'string') return array;
+        if (!Array.isArray(array)) return '';
+        const sep = typeof separator === 'string' ? separator : ', ';
+        return array.join(sep);
+};
+
+const equalsLength = (value: any[] | string, length: number, options?: any): any => {
+        const len = (Array.isArray(value) || typeof value === 'string') ? value.length : 0;
+        const result = len === length;
+        if (options && typeof options.fn === 'function') {
+                return result ? options.fn(this) : options.inverse(this);
+        }
+        return String(result);
+};
+
+const last = (value: any[] | string, n?: number): any => {
+        if (!Array.isArray(value) && typeof value !== 'string') {
+                return '';
+        }
+        if (!isNumber(n)) {
+                return (value as any)[(value as any).length - 1];
+        }
+        const arr = value as any[] | string;
+        return arr.slice(-Math.abs(Number(n)));
+};
+
+const length = (value: any): number => {
+        if (typeof value === 'string' || Array.isArray(value)) {
+                return value.length;
+        }
+        if (typeof value === 'object' && value !== null) {
+                return Object.keys(value).length;
+        }
+        return 0;
+};
+
+const lengthEqual = equalsLength;
+
+const mapHelper = (array: any[], iter: (value: any, index: number, array: any[]) => any): any => {
+        if (!Array.isArray(array)) return '';
+        if (typeof iter !== 'function') {
+                return array;
+        }
+        return array.map(iter);
+};
+
+const pluck = (arr: any[], prop: string): any[] => {
+        if (!Array.isArray(arr)) return [];
+        const res: any[] = [];
+        for (let i = 0; i < arr.length; i++) {
+                const val = get(arr[i], prop);
+                if (typeof val !== 'undefined') {
+                        res.push(val);
+                }
+        }
+        return res;
+};
+
+const reverse = (val: any[] | string): any => {
+        if (Array.isArray(val)) {
+                return [...val].reverse();
+        }
+        if (typeof val === 'string') {
+                return val.split('').reverse().join('');
+        }
+        return val;
+};
+
+const some = (array: any[], iter: (value: any, index: number, array: any[]) => boolean, options: any): string => {
+        if (Array.isArray(array)) {
+                for (let i = 0; i < array.length; i++) {
+                        if (iter(array[i], i, array)) {
+                                return options.fn(this);
+                        }
+                }
+        }
+        return options.inverse(this);
+};
+
+const sort = (array: any[], options: any): any[] | string => {
+        if (!Array.isArray(array)) return '';
+        const result = [...array].sort();
+        if (options && options.hash && options.hash.reverse) {
+                return result.reverse();
+        }
+        return result;
+};
+
+const sortBy = (array: any[], prop: any, options: any): any[] | string => {
+        if (!Array.isArray(array)) return '';
+        const args = Array.prototype.slice.call(arguments, 0);
+        args.pop();
+        if (typeof prop !== 'string' && typeof prop !== 'function') {
+                return [...array].sort();
+        }
+        if (typeof prop === 'function') {
+                return [...array].sort(prop);
+        }
+        return [...array].sort((a, b) => {
+                const va = get(a, prop);
+                const vb = get(b, prop);
+                if (va > vb) return 1;
+                if (va < vb) return -1;
+                return 0;
+        });
+};
+
+const withAfter = (array: any[], idx: number, options: any): string => {
+        if (!Array.isArray(array)) return '';
+        array = array.slice(idx);
+        let result = '';
+        for (const item of array) {
+                result += options.fn(item);
+        }
+        return result;
+};
+
+const withBefore = (array: any[], idx: number, options: any): string => {
+        if (!Array.isArray(array)) return '';
+        array = array.slice(0, -idx);
+        let result = '';
+        for (const item of array) {
+                result += options.fn(item);
+        }
+        return result;
+};
+
+const withFirst = (array: any[], idx: number | undefined, options: any): string => {
+        if (!Array.isArray(array)) return '';
+        if (!isNumber(idx)) {
+                return options.fn(array[0]);
+        }
+        array = array.slice(0, idx);
+        let result = '';
+        for (const item of array) {
+                result += options.fn(item);
+        }
+        return result;
+};
+
+const withGroup = (array: any[], size: number, options: any): string => {
+        let result = '';
+        if (Array.isArray(array) && array.length > 0) {
+                let sub: any[] = [];
+                for (let i = 0; i < array.length; i++) {
+                        if (i > 0 && i % size === 0) {
+                                result += options.fn(sub);
+                                sub = [];
+                        }
+                        sub.push(array[i]);
+                }
+                result += options.fn(sub);
+        }
+        return result;
+};
+
+const withLast = (array: any[], idx: number | undefined, options: any): string => {
+        if (!Array.isArray(array)) return '';
+        if (!isNumber(idx)) {
+                return options.fn(array[array.length - 1]);
+        }
+        array = array.slice(-idx);
+        let result = '';
+        for (const item of array) {
+                result += options.fn(item);
+        }
+        return result;
+};
+
+const withSort = (array: any[], prop: any, options: any): string => {
+        if (!Array.isArray(array)) return '';
+        let arr: any[];
+        if (typeof prop === 'undefined') {
+                arr = [...array].sort();
+                if (options && options.hash && options.hash.reverse) {
+                        arr = arr.reverse();
+                }
+        } else {
+                arr = [...array].sort((a, b) => {
+                        const va = get(a, prop);
+                        const vb = get(b, prop);
+                        if (va > vb) return 1;
+                        if (va < vb) return -1;
+                        return 0;
+                });
+                if (options && options.hash && options.hash.reverse) {
+                        arr = arr.reverse();
+                }
+        }
+        return arr.map((v) => options.fn(v)).join('');
+};
+
+const unique = (array: any[]): any[] => {
+        if (!Array.isArray(array)) return [];
+        return array.filter((item, index, arr) => arr.indexOf(item) === index);
+};
+
+export const helpers: Helper[] = [
+        { name: 'after', category: 'array', fn: after },
+        { name: 'arrayify', category: 'array', fn: arrayify },
+        { name: 'before', category: 'array', fn: before },
+        { name: 'eachIndex', category: 'array', fn: eachIndex },
+        { name: 'filter', category: 'array', fn: filter },
+        { name: 'first', category: 'array', fn: first },
+        { name: 'forEach', category: 'array', fn: forEach },
+        { name: 'inArray', category: 'array', fn: inArray },
+        { name: 'isArray', category: 'array', fn: isArray },
+        { name: 'itemAt', category: 'array', fn: itemAt },
+        { name: 'join', category: 'array', fn: join },
+        { name: 'equalsLength', category: 'array', fn: equalsLength },
+        { name: 'last', category: 'array', fn: last },
+        { name: 'length', category: 'array', fn: length },
+        { name: 'lengthEqual', category: 'array', fn: lengthEqual },
+        { name: 'map', category: 'array', fn: mapHelper },
+        { name: 'pluck', category: 'array', fn: pluck },
+        { name: 'reverse', category: 'array', fn: reverse },
+        { name: 'some', category: 'array', fn: some },
+        { name: 'sort', category: 'array', fn: sort },
+        { name: 'sortBy', category: 'array', fn: sortBy },
+        { name: 'withAfter', category: 'array', fn: withAfter },
+        { name: 'withBefore', category: 'array', fn: withBefore },
+        { name: 'withFirst', category: 'array', fn: withFirst },
+        { name: 'withGroup', category: 'array', fn: withGroup },
+        { name: 'withLast', category: 'array', fn: withLast },
+        { name: 'withSort', category: 'array', fn: withSort },
+        { name: 'unique', category: 'array', fn: unique },
+];

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -1,330 +1,449 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 import {type Helper} from '../helper-registry.js';
 
 // Utility helpers
 const isNumber = (value: unknown): value is number => {
-        if (typeof value === 'number') {
-                return !Number.isNaN(value);
-        }
-        if (typeof value === 'string' && value.trim() !== '') {
-                return !Number.isNaN(Number(value));
-        }
-        return false;
+	if (typeof value === 'number') {
+		return !Number.isNaN(value);
+	}
+
+	if (typeof value === 'string' && value.trim() !== '') {
+		return !Number.isNaN(Number(value));
+	}
+
+	return false;
 };
 
-const get = (obj: any, path: string): any => {
-        if (!obj || typeof path !== 'string') {
-                return undefined;
-        }
-        return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+const get = (object: any, path: string): any => {
+	if (!object || typeof path !== 'string') {
+		return undefined;
+	}
+
+	// eslint-disable-next-line unicorn/no-array-reduce
+	return path.split('.').reduce((accumulator, key) => (accumulator ? accumulator[key] : undefined), object);
 };
 
-const after = (array: any[], n: number): any[] => {
-        if (!Array.isArray(array)) return [];
-        return array.slice(n);
+const after = (array: any[], n: number, options?: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	const result = array.slice(n);
+	if (options && typeof options.fn === 'function') {
+		return result.map((item: any) => options.fn(item)).join('');
+	}
+
+	return result.join(', ');
 };
 
-const arrayify = (value: any): any[] => {
-        return value ? (Array.isArray(value) ? value : [value]) : [];
+const arrayify = (value: any): string => {
+	const arr = value ? (Array.isArray(value) ? value : [value]) : [];
+	return arr.join(', ');
 };
 
-const before = (array: any[], n: number): any[] => {
-        if (!Array.isArray(array)) return [];
-        return array.slice(0, -n);
+const before = (array: any[], n: number): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	return array.slice(0, -n).join(', ');
 };
 
 const eachIndex = (array: any[], options: any): string => {
-        if (!Array.isArray(array)) return '';
-        let result = '';
-        for (let i = 0; i < array.length; i++) {
-                result += options.fn({item: array[i], index: i});
-        }
-        return result;
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	let result = '';
+	for (const [i, element] of array.entries()) {
+		result += options.fn({item: element, index: i}) as string;
+	}
+
+	return result;
 };
 
-interface FilterHash { property?: string; prop?: string; }
+type FilterHash = {
+	property?: string; prop?: string;
+};
 const filter = (array: any[], value: any, options: any): string => {
-        if (!Array.isArray(array)) return options.inverse(this);
-        const hash: FilterHash = options.hash || {};
-        const prop = hash.property || hash.prop;
-        const results = prop
-                ? array.filter((val) => value === get(val, prop))
-                : array.filter((v) => value === v);
-        if (results.length > 0) {
-                return results.map((r: any) => options.fn(r)).join('');
-        }
-        return options.inverse(this);
+	if (!Array.isArray(array)) {
+		return options.inverse(this);
+	}
+
+	const hash: FilterHash = options.hash || {};
+	const property = hash.property ?? hash.prop;
+	const results = property
+		? array.filter(value_ => value === get(value_, property))
+		: array.filter(v => value === v);
+	if (results.length > 0) {
+		return results.map((r: any) => options.fn(r)).join('');
+	}
+
+	return options.inverse(this);
 };
 
 const first = (array: any[], n?: number): any => {
-        if (!Array.isArray(array)) return '';
-        if (!isNumber(n)) {
-                return array[0];
-        }
-        return array.slice(0, n);
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	if (!isNumber(n)) {
+		return array[0];
+	}
+
+	return array.slice(0, n);
 };
 
 const forEach = (array: any[], options: any): string => {
-        if (!Array.isArray(array)) return '';
-        const len = array.length;
-        let buffer = '';
-        for (let i = 0; i < len; i++) {
-                const item = array[i];
-                const data = {
-                        index: i,
-                };
-                item.index = i + 1;
-                item.total = len;
-                item.isFirst = i === 0;
-                item.isLast = i === len - 1;
-                buffer += options.fn(item, {data});
-        }
-        return buffer;
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	const length_ = array.length;
+	let buffer = '';
+	for (let i = 0; i < length_; i++) {
+		const item = array[i];
+		const data = {
+			index: i,
+		};
+		item.index = i + 1;
+		item.total = length_;
+		item.isFirst = i === 0;
+		item.isLast = i === length_ - 1;
+		buffer += options.fn(item, {data}) as string;
+	}
+
+	return buffer;
 };
 
 const inArray = (array: any[], value: any, options: any): any => {
-        const found = Array.isArray(array) && array.indexOf(value) > -1;
-        if (options && typeof options.fn === 'function') {
-                return found ? options.fn(this) : options.inverse(this);
-        }
-        return found;
+	const found = Array.isArray(array) && array.includes(value);
+	if (options && typeof options.fn === 'function') {
+		return found ? options.fn(this) : options.inverse(this);
+	}
+
+	return found;
 };
 
-const isArray = (value: any): boolean => Array.isArray(value);
+const isArray = (value: any): string => Array.isArray(value).toString();
 
-const itemAt = (array: any[], idx?: number): any => {
-        if (!Array.isArray(array)) return null;
-        const i = isNumber(idx) ? Number(idx) : 0;
-        if (i < 0) {
-                return array[array.length + i];
-        }
-        return array[i];
+const itemAt = (array: any[], index?: number): any => {
+	if (!Array.isArray(array)) {
+		return null;
+	}
+
+	const i = isNumber(index) ? Number(index) : 0;
+	if (i < 0) {
+		return array[array.length + i];
+	}
+
+	return array[i];
 };
 
 const join = (array: any[] | string, separator?: string): string => {
-        if (typeof array === 'string') return array;
-        if (!Array.isArray(array)) return '';
-        const sep = typeof separator === 'string' ? separator : ', ';
-        return array.join(sep);
+	if (typeof array === 'string') {
+		return array;
+	}
+
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	const separator_ = typeof separator === 'string' ? separator : ', ';
+	return array.join(separator_);
 };
 
 const equalsLength = (value: any[] | string, length: number, options?: any): any => {
-        const len = (Array.isArray(value) || typeof value === 'string') ? value.length : 0;
-        const result = len === length;
-        if (options && typeof options.fn === 'function') {
-                return result ? options.fn(this) : options.inverse(this);
-        }
-        return String(result);
+	const length_ = (Array.isArray(value) || typeof value === 'string') ? value.length : 0;
+	const result = length_ === length;
+	if (options && typeof options.fn === 'function') {
+		return result ? options.fn(this) : options.inverse(this);
+	}
+
+	return String(result);
 };
 
 const last = (value: any[] | string, n?: number): any => {
-        if (!Array.isArray(value) && typeof value !== 'string') {
-                return '';
-        }
-        if (!isNumber(n)) {
-                return (value as any)[(value as any).length - 1];
-        }
-        const arr = value as any[] | string;
-        return arr.slice(-Math.abs(Number(n)));
+	if (!Array.isArray(value) && typeof value !== 'string') {
+		return '';
+	}
+
+	if (!isNumber(n)) {
+		return (value as any)[(value as any).length - 1];
+	}
+
+	const array = value;
+	return array.slice(-Math.abs(Number(n)));
 };
 
-const length = (value: any): number => {
-        if (typeof value === 'string' || Array.isArray(value)) {
-                return value.length;
-        }
-        if (typeof value === 'object' && value !== null) {
-                return Object.keys(value).length;
-        }
-        return 0;
+const length = (value: any): string => {
+	if (typeof value === 'string' || Array.isArray(value)) {
+		return value.length.toString();
+	}
+
+	if (typeof value === 'object' && value !== null) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		return Object.keys(value).length.toString();
+	}
+
+	return '0';
 };
 
 const lengthEqual = equalsLength;
 
-const mapHelper = (array: any[], iter: (value: any, index: number, array: any[]) => any): any => {
-        if (!Array.isArray(array)) return '';
-        if (typeof iter !== 'function') {
-                return array;
-        }
-        return array.map(iter);
+const mapHelper = (array: any[], iterator: (value: any, index: number, array: any[]) => any): any => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	if (typeof iterator !== 'function') {
+		return array;
+	}
+
+	// eslint-disable-next-line unicorn/no-array-callback-reference
+	return array.map(iterator);
 };
 
-const pluck = (arr: any[], prop: string): any[] => {
-        if (!Array.isArray(arr)) return [];
-        const res: any[] = [];
-        for (let i = 0; i < arr.length; i++) {
-                const val = get(arr[i], prop);
-                if (typeof val !== 'undefined') {
-                        res.push(val);
-                }
-        }
-        return res;
+const pluck = (array: any[], property: string): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	// eslint-disable-next-line unicorn/prevent-abbreviations
+	const res: any[] = [];
+	for (const element of array) {
+		const value = get(element, property);
+		if (value !== undefined) {
+			res.push(value);
+		}
+	}
+
+	return res.join(', ');
 };
 
-const reverse = (val: any[] | string): any => {
-        if (Array.isArray(val)) {
-                return [...val].reverse();
-        }
-        if (typeof val === 'string') {
-                return val.split('').reverse().join('');
-        }
-        return val;
+const reverse = (value: any[] | string): any => {
+	if (Array.isArray(value)) {
+		return [...value].reverse();
+	}
+
+	if (typeof value === 'string') {
+		return value.split('').reverse().join('');
+	}
+
+	return value;
 };
 
-const some = (array: any[], iter: (value: any, index: number, array: any[]) => boolean, options: any): string => {
-        if (Array.isArray(array)) {
-                for (let i = 0; i < array.length; i++) {
-                        if (iter(array[i], i, array)) {
-                                return options.fn(this);
-                        }
-                }
-        }
-        return options.inverse(this);
+const some = (array: any[], iterator: (value: any, index: number, array: any[]) => boolean, options: any): string => {
+	if (Array.isArray(array)) {
+		for (let i = 0; i < array.length; i++) {
+			if (iterator(array[i], i, array)) {
+				return options.fn(this);
+			}
+		}
+	}
+
+	return options.inverse(this);
 };
 
-const sort = (array: any[], options: any): any[] | string => {
-        if (!Array.isArray(array)) return '';
-        const result = [...array].sort();
-        if (options && options.hash && options.hash.reverse) {
-                return result.reverse();
-        }
-        return result;
+const sort = (array: any[], options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+	let result = [...array].sort();
+	if (options?.hash?.reverse) {
+		result = result.reverse();
+	}
+
+	return result.join(', ');
 };
 
-const sortBy = (array: any[], prop: any, options: any): any[] | string => {
-        if (!Array.isArray(array)) return '';
-        const args = Array.prototype.slice.call(arguments, 0);
-        args.pop();
-        if (typeof prop !== 'string' && typeof prop !== 'function') {
-                return [...array].sort();
-        }
-        if (typeof prop === 'function') {
-                return [...array].sort(prop);
-        }
-        return [...array].sort((a, b) => {
-                const va = get(a, prop);
-                const vb = get(b, prop);
-                if (va > vb) return 1;
-                if (va < vb) return -1;
-                return 0;
-        });
+const sortBy = (array: any[], property: any, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	const arguments_ = Array.prototype.slice.call(options, 0);
+	arguments_.pop();
+	let sorted: any[];
+	if (typeof property !== 'string' && typeof property !== 'function') {
+		// eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+		sorted = [...array].sort();
+	} else if (typeof property === 'function') {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		sorted = [...array].sort(property);
+	} else {
+		sorted = [...array].sort((a, b) => {
+			const va = get(a, property as string);
+			const vb = get(b, property as string);
+			if (va > vb) {
+				return 1;
+			}
+
+			if (va < vb) {
+				return -1;
+			}
+
+			return 0;
+		});
+	}
+	return sorted.join(', ');
 };
 
-const withAfter = (array: any[], idx: number, options: any): string => {
-        if (!Array.isArray(array)) return '';
-        array = array.slice(idx);
-        let result = '';
-        for (const item of array) {
-                result += options.fn(item);
-        }
-        return result;
+const withAfter = (array: any[], index: number, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	array = array.slice(index);
+	let result = '';
+	for (const item of array) {
+		result += options.fn(item) as string;
+	}
+
+	return result;
 };
 
-const withBefore = (array: any[], idx: number, options: any): string => {
-        if (!Array.isArray(array)) return '';
-        array = array.slice(0, -idx);
-        let result = '';
-        for (const item of array) {
-                result += options.fn(item);
-        }
-        return result;
+const withBefore = (array: any[], index: number, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	array = array.slice(0, -index);
+	let result = '';
+	for (const item of array) {
+		result += options.fn(item) as string;
+	}
+
+	return result;
 };
 
-const withFirst = (array: any[], idx: number | undefined, options: any): string => {
-        if (!Array.isArray(array)) return '';
-        if (!isNumber(idx)) {
-                return options.fn(array[0]);
-        }
-        array = array.slice(0, idx);
-        let result = '';
-        for (const item of array) {
-                result += options.fn(item);
-        }
-        return result;
+const withFirst = (array: any[], index: number | undefined, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	if (!isNumber(index)) {
+		return options.fn(array[0]);
+	}
+
+	array = array.slice(0, index);
+	let result = '';
+	for (const item of array) {
+		result += options.fn(item) as string;
+	}
+
+	return result;
 };
 
 const withGroup = (array: any[], size: number, options: any): string => {
-        let result = '';
-        if (Array.isArray(array) && array.length > 0) {
-                let sub: any[] = [];
-                for (let i = 0; i < array.length; i++) {
-                        if (i > 0 && i % size === 0) {
-                                result += options.fn(sub);
-                                sub = [];
-                        }
-                        sub.push(array[i]);
-                }
-                result += options.fn(sub);
-        }
-        return result;
+	let result = '';
+	if (Array.isArray(array) && array.length > 0) {
+		let sub: any[] = [];
+		for (const [i, element] of array.entries()) {
+			if (i > 0 && i % size === 0) {
+				result += options.fn(sub) as string;
+				sub = [];
+			}
+
+			sub.push(element);
+		}
+
+		result += options.fn(sub) as string;
+	}
+
+	return result;
 };
 
-const withLast = (array: any[], idx: number | undefined, options: any): string => {
-        if (!Array.isArray(array)) return '';
-        if (!isNumber(idx)) {
-                return options.fn(array[array.length - 1]);
-        }
-        array = array.slice(-idx);
-        let result = '';
-        for (const item of array) {
-                result += options.fn(item);
-        }
-        return result;
+const withLast = (array: any[], index: number | undefined, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	if (!isNumber(index)) {
+		return options.fn(array[array.length - 1]);
+	}
+
+	array = array.slice(-index);
+	let result = '';
+	for (const item of array) {
+		result += options.fn(item) as string;
+	}
+
+	return result;
 };
 
-const withSort = (array: any[], prop: any, options: any): string => {
-        if (!Array.isArray(array)) return '';
-        let arr: any[];
-        if (typeof prop === 'undefined') {
-                arr = [...array].sort();
-                if (options && options.hash && options.hash.reverse) {
-                        arr = arr.reverse();
-                }
-        } else {
-                arr = [...array].sort((a, b) => {
-                        const va = get(a, prop);
-                        const vb = get(b, prop);
-                        if (va > vb) return 1;
-                        if (va < vb) return -1;
-                        return 0;
-                });
-                if (options && options.hash && options.hash.reverse) {
-                        arr = arr.reverse();
-                }
-        }
-        return arr.map((v) => options.fn(v)).join('');
+const withSort = (array: any[], property: any, options: any): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	let array_: any[];
+	if (property === undefined) {
+		// eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+		array_ = [...array].sort();
+		if (options?.hash?.reverse) {
+			array_ = array_.reverse();
+		}
+	} else {
+		array_ = [...array].sort((a, b) => {
+			const va = get(a, property as string);
+			const vb = get(b, property as string);
+			if (va > vb) {
+				return 1;
+			}
+
+			if (va < vb) {
+				return -1;
+			}
+
+			return 0;
+		});
+		if (options?.hash?.reverse) {
+			array_ = array_.reverse();
+		}
+	}
+
+	return array_.map(v => options.fn(v)).join('');
 };
 
-const unique = (array: any[]): any[] => {
-        if (!Array.isArray(array)) return [];
-        return array.filter((item, index, arr) => arr.indexOf(item) === index);
+const unique = (array: any[]): string => {
+	if (!Array.isArray(array)) {
+		return '';
+	}
+
+	const uniqueArray = array.filter((item, index, array_) => array_.indexOf(item) === index);
+	return uniqueArray.join(', ');
 };
 
 export const helpers: Helper[] = [
-        { name: 'after', category: 'array', fn: after },
-        { name: 'arrayify', category: 'array', fn: arrayify },
-        { name: 'before', category: 'array', fn: before },
-        { name: 'eachIndex', category: 'array', fn: eachIndex },
-        { name: 'filter', category: 'array', fn: filter },
-        { name: 'first', category: 'array', fn: first },
-        { name: 'forEach', category: 'array', fn: forEach },
-        { name: 'inArray', category: 'array', fn: inArray },
-        { name: 'isArray', category: 'array', fn: isArray },
-        { name: 'itemAt', category: 'array', fn: itemAt },
-        { name: 'join', category: 'array', fn: join },
-        { name: 'equalsLength', category: 'array', fn: equalsLength },
-        { name: 'last', category: 'array', fn: last },
-        { name: 'length', category: 'array', fn: length },
-        { name: 'lengthEqual', category: 'array', fn: lengthEqual },
-        { name: 'map', category: 'array', fn: mapHelper },
-        { name: 'pluck', category: 'array', fn: pluck },
-        { name: 'reverse', category: 'array', fn: reverse },
-        { name: 'some', category: 'array', fn: some },
-        { name: 'sort', category: 'array', fn: sort },
-        { name: 'sortBy', category: 'array', fn: sortBy },
-        { name: 'withAfter', category: 'array', fn: withAfter },
-        { name: 'withBefore', category: 'array', fn: withBefore },
-        { name: 'withFirst', category: 'array', fn: withFirst },
-        { name: 'withGroup', category: 'array', fn: withGroup },
-        { name: 'withLast', category: 'array', fn: withLast },
-        { name: 'withSort', category: 'array', fn: withSort },
-        { name: 'unique', category: 'array', fn: unique },
+	{name: 'after', category: 'array', fn: after},
+	{name: 'arrayify', category: 'array', fn: arrayify},
+	{name: 'before', category: 'array', fn: before},
+	{name: 'eachIndex', category: 'array', fn: eachIndex},
+	{name: 'filter', category: 'array', fn: filter},
+	{name: 'first', category: 'array', fn: first},
+	{name: 'forEach', category: 'array', fn: forEach},
+	{name: 'inArray', category: 'array', fn: inArray},
+	{name: 'isArray', category: 'array', fn: isArray},
+	{name: 'itemAt', category: 'array', fn: itemAt},
+	{name: 'join', category: 'array', fn: join},
+	{name: 'equalsLength', category: 'array', fn: equalsLength},
+	{name: 'last', category: 'array', fn: last},
+	{name: 'length', category: 'array', fn: length},
+	{name: 'lengthEqual', category: 'array', fn: lengthEqual},
+	{name: 'map', category: 'array', fn: mapHelper},
+	{name: 'pluck', category: 'array', fn: pluck},
+	{name: 'reverse', category: 'array', fn: reverse},
+	{name: 'some', category: 'array', fn: some},
+	{name: 'sort', category: 'array', fn: sort},
+	{name: 'sortBy', category: 'array', fn: sortBy},
+	{name: 'withAfter', category: 'array', fn: withAfter},
+	{name: 'withBefore', category: 'array', fn: withBefore},
+	{name: 'withFirst', category: 'array', fn: withFirst},
+	{name: 'withGroup', category: 'array', fn: withGroup},
+	{name: 'withLast', category: 'array', fn: withLast},
+	{name: 'withSort', category: 'array', fn: withSort},
+	{name: 'unique', category: 'array', fn: unique},
 ];

--- a/test/helpers/array.test.ts
+++ b/test/helpers/array.test.ts
@@ -2,38 +2,38 @@ import {describe, it, expect} from 'vitest';
 import {helpers} from '../../src/helpers/array.js';
 
 describe('array helpers', () => {
-        it('should expose the after helper', () => {
-                const afterHelper = helpers.find(h => h.name === 'after');
-                expect(afterHelper).toBeDefined();
-                expect(afterHelper?.category).toBe('array');
-                expect(typeof afterHelper?.fn).toBe('function');
-        });
+	it('should expose the after helper', () => {
+		const afterHelper = helpers.find(h => h.name === 'after');
+		expect(afterHelper).toBeDefined();
+		expect(afterHelper?.category).toBe('array');
+		expect(typeof afterHelper?.fn).toBe('function');
+	});
 
-        it('after should return items after index', () => {
-                const afterHelper = helpers.find(h => h.name === 'after');
-                const fn = afterHelper?.fn as (arr: any[], n: number) => any[];
-                expect(fn(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
-        });
+	it('after should return items after index', () => {
+		const afterHelper = helpers.find(h => h.name === 'after');
+		const function_ = afterHelper?.fn as (array: any[], n: number) => any[];
+		expect(function_(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
+	});
 
-        it('arrayify should wrap non-array values', () => {
-                const arrayify = helpers.find(h => h.name === 'arrayify')?.fn as (v: any) => any[];
-                expect(arrayify('foo')).toEqual(['foo']);
-                expect(arrayify(['foo'])).toEqual(['foo']);
-        });
+	it('arrayify should wrap non-array values', () => {
+		const arrayify = helpers.find(h => h.name === 'arrayify')?.fn as (v: any) => any[];
+		expect(arrayify('foo')).toEqual(['foo']);
+		expect(arrayify(['foo'])).toEqual(['foo']);
+	});
 
-        it('isArray should detect arrays', () => {
-                const isArray = helpers.find(h => h.name === 'isArray')?.fn as (v: any) => boolean;
-                expect(isArray([])).toBe(true);
-                expect(isArray('foo')).toBe(false);
-        });
+	it('isArray should detect arrays', () => {
+		const isArray = helpers.find(h => h.name === 'isArray')?.fn as (v: any) => boolean;
+		expect(isArray([])).toBe(true);
+		expect(isArray('foo')).toBe(false);
+	});
 
-        it('join should join arrays', () => {
-                const join = helpers.find(h => h.name === 'join')?.fn as (arr: any[], sep?: string) => string;
-                expect(join(['a', 'b', 'c'], ',')).toBe('a,b,c');
-        });
+	it('join should join arrays', () => {
+		const join = helpers.find(h => h.name === 'join')?.fn as (array: any[], separator?: string) => string;
+		expect(join(['a', 'b', 'c'], ',')).toBe('a,b,c');
+	});
 
-        it('unique should remove duplicate values', () => {
-                const unique = helpers.find(h => h.name === 'unique')?.fn as (arr: any[]) => any[];
-                expect(unique(['a','a','b','b','c'])).toEqual(['a','b','c']);
-        });
+	it('unique should remove duplicate values', () => {
+		const unique = helpers.find(h => h.name === 'unique')?.fn as (array: any[]) => any[];
+		expect(unique(['a', 'a', 'b', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+	});
 });

--- a/test/helpers/array.test.ts
+++ b/test/helpers/array.test.ts
@@ -1,0 +1,39 @@
+import {describe, it, expect} from 'vitest';
+import {helpers} from '../../src/helpers/array.js';
+
+describe('array helpers', () => {
+        it('should expose the after helper', () => {
+                const afterHelper = helpers.find(h => h.name === 'after');
+                expect(afterHelper).toBeDefined();
+                expect(afterHelper?.category).toBe('array');
+                expect(typeof afterHelper?.fn).toBe('function');
+        });
+
+        it('after should return items after index', () => {
+                const afterHelper = helpers.find(h => h.name === 'after');
+                const fn = afterHelper?.fn as (arr: any[], n: number) => any[];
+                expect(fn(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
+        });
+
+        it('arrayify should wrap non-array values', () => {
+                const arrayify = helpers.find(h => h.name === 'arrayify')?.fn as (v: any) => any[];
+                expect(arrayify('foo')).toEqual(['foo']);
+                expect(arrayify(['foo'])).toEqual(['foo']);
+        });
+
+        it('isArray should detect arrays', () => {
+                const isArray = helpers.find(h => h.name === 'isArray')?.fn as (v: any) => boolean;
+                expect(isArray([])).toBe(true);
+                expect(isArray('foo')).toBe(false);
+        });
+
+        it('join should join arrays', () => {
+                const join = helpers.find(h => h.name === 'join')?.fn as (arr: any[], sep?: string) => string;
+                expect(join(['a', 'b', 'c'], ',')).toBe('a,b,c');
+        });
+
+        it('unique should remove duplicate values', () => {
+                const unique = helpers.find(h => h.name === 'unique')?.fn as (arr: any[]) => any[];
+                expect(unique(['a','a','b','b','c'])).toEqual(['a','b','c']);
+        });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES6", // or your preferred target version
+        "target": "ES2016", // or your preferred target version
         "module": "commonjs", // or your preferred module type
         "allowJs": true, // Enable JavaScript files in the project
         "checkJs": false, // Set to true if you want type-checking for JS files


### PR DESCRIPTION
## Summary
- implement `array` helpers in TypeScript
- register new helpers in `HelperRegistry`
- switch npm scripts to pnpm
- update README for pnpm instructions
- add new tests for array helpers (not executed)

## Testing
- Skipped running tests per request