### PR TITLE
fix: register return value

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -30,14 +30,14 @@ export class HelperRegistry {
 		this.registerHelpers(dateHelpers);
 	}
 
-	public register(helper: Helper): boolean {
-		const result = false;
-		if (!this.has(helper.name)) {
-			this._helpers.push(helper);
-		}
+    public register(helper: Helper): boolean {
+            if (!this.has(helper.name)) {
+                    this._helpers.push(helper);
+                    return true;
+            }
 
-		return result;
-	}
+            return false;
+    }
 
 	public registerHelpers(helpers: Helper[]) {
 		for (const helper of helpers) {

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -9,15 +9,25 @@ describe('HelperRegistry', () => {
 });
 
 describe('HelperRegistry Register', () => {
-	test('should register a helper', () => {
-		const registry = new HelperRegistry();
-		registry.register({
-			name: 'test',
-			category: 'test',
-			fn: () => 'test',
-		});
-		expect(registry.has('test')).toBeTruthy();
-	});
+        test('should register a helper', () => {
+                const registry = new HelperRegistry();
+                registry.register({
+                        name: 'test',
+                        category: 'test',
+                        fn: () => 'test',
+                });
+                expect(registry.has('test')).toBeTruthy();
+        });
+
+        test('register should return true on first registration', () => {
+                const registry = new HelperRegistry();
+                const result = registry.register({
+                        name: 'test-return',
+                        category: 'test',
+                        fn: () => 'test',
+                });
+                expect(result).toBeTruthy();
+        });
 
 	test('should not register a helper twice', () => {
 		const registry = new HelperRegistry();


### PR DESCRIPTION
## Summary
- fix return value of `HelperRegistry.register`
- test expected true on successful register

## Testing
- `npm test` *(fails: xo not found)*