### PR TITLE
feat: add code helpers in TypeScript

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
 import type Handlebars from "handlebars";
 import { helpers as arrayHelpers } from "./helpers/array.js";
+import { helpers as codeHelpers } from "./helpers/code.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
@@ -36,6 +37,8 @@ export class HelperRegistry {
 		this.registerHelpers(arrayHelpers);
 		// Date
 		this.registerHelpers(dateHelpers);
+		// Code
+		this.registerHelpers(codeHelpers);
 		// Markdown
 		this.registerHelpers(mdHelpers);
 	}

--- a/src/helpers/code.ts
+++ b/src/helpers/code.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import tag from "html-tag";
+import codeBlock from "to-gfm-code-block";
+import type { Helper } from "../helper-registry.js";
+
+const embed = (filepath: string, language?: string): string => {
+	let ext =
+		typeof language === "string" ? language : path.extname(filepath).slice(1);
+	let code = fs.readFileSync(filepath, "utf8");
+	if (ext === "markdown" || ext === "md") {
+		ext = "markdown";
+		code = code.split("`").join("&#x60");
+	}
+	return `${codeBlock(code, ext).trim()}\n`;
+};
+
+const gist = (id: string): string => {
+	return tag("script", { src: `https://gist.github.com/${id}.js` });
+};
+
+type JsfiddleOptions = {
+	id?: string;
+	width?: string;
+	height?: string;
+	skin?: string;
+	tabs?: string;
+	allowfullscreen?: string;
+	frameborder?: string;
+};
+
+const jsfiddle = (options: JsfiddleOptions): string => {
+	if (!options || !options.id) {
+		throw new Error("jsfiddle helper expects an `id`");
+	}
+	const {
+		id,
+		width = "100%",
+		height = "300",
+		skin = "/presentation/",
+		tabs = "result,js,html,css",
+		allowfullscreen = "allowfullscreen",
+		frameborder = "0",
+	} = options;
+	const src = `http://jsfiddle.net/${id}/embedded/${tabs}${skin}`;
+	return tag("iframe", { width, height, src, allowfullscreen, frameborder });
+};
+
+export const helpers: Helper[] = [
+	{ name: "embed", category: "code", fn: embed },
+	{ name: "gist", category: "code", fn: gist },
+	{ name: "jsfiddle", category: "code", fn: jsfiddle },
+];
+
+export { embed, gist, jsfiddle };

--- a/test/helpers/code.test.ts
+++ b/test/helpers/code.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/code.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("embed", () => {
+	const embedFn = getHelper("embed");
+	it("embeds code and detects language from extension", () => {
+		const result = embedFn("helpers/test/fixtures/simple.md");
+		expect(result.startsWith("```markdown")).toBe(true);
+		expect(result.endsWith("```\n")).toBe(true);
+	});
+	it("escapes backticks in markdown", () => {
+		const result = embedFn("helpers/test/fixtures/embedded.md");
+		expect(result.includes("&#x60&#x60&#x60js")).toBe(true);
+	});
+	it("uses provided language", () => {
+		const result = embedFn("helpers/test/fixtures/index.html", "hbs");
+		expect(result.startsWith("```hbs")).toBe(true);
+	});
+});
+
+describe("gist", () => {
+	const gistFn = getHelper("gist");
+	it("returns a gist script tag", () => {
+		expect(gistFn("abcdefg")).toBe(
+			'<script src="https://gist.github.com/abcdefg.js"></script>',
+		);
+	});
+});
+
+describe("jsfiddle", () => {
+	const jsfiddleFn = getHelper("jsfiddle");
+	it("returns a jsfiddle embed link, with default tabs", () => {
+		expect(jsfiddleFn({ id: "UXbas" })).toBe(
+			'<iframe width="100%" height="300" src="http://jsfiddle.net/UXbas/embedded/result,js,html,css/presentation/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>',
+		);
+	});
+	it("throws if id is missing", () => {
+		expect(() => jsfiddleFn({})).toThrow();
+	});
+	it("returns a jsfiddle embed link, with custom tabs assigned", () => {
+		expect(jsfiddleFn({ id: "UXbas", tabs: "html,css" })).toBe(
+			'<iframe width="100%" height="300" src="http://jsfiddle.net/UXbas/embedded/html,css/presentation/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- migrate code helpers to TypeScript (embed, gist, jsfiddle)
- wire code helpers into helper registry
- cover code helpers with Vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689636a6a36483249f6c2cbaa0bd428a