### PR TITLE
feat: add collection helper

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -2,6 +2,7 @@
 import type Handlebars from "handlebars";
 import { helpers as arrayHelpers } from "./helpers/array.js";
 import { helpers as codeHelpers } from "./helpers/code.js";
+import { helpers as collectionHelpers } from "./helpers/collection.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
@@ -35,6 +36,8 @@ export class HelperRegistry {
 	public init() {
 		// Array
 		this.registerHelpers(arrayHelpers);
+		// Collection
+		this.registerHelpers(collectionHelpers);
 		// Date
 		this.registerHelpers(dateHelpers);
 		// Code

--- a/src/helpers/collection.ts
+++ b/src/helpers/collection.ts
@@ -1,0 +1,38 @@
+import type { Helper } from "../helper-registry.js";
+
+const isEmpty = (collection?: unknown): boolean => {
+	if (collection == null) return true;
+	if (Array.isArray(collection)) return collection.length === 0;
+	if (typeof collection === "object")
+		return Object.keys(collection).length === 0;
+	return false;
+};
+
+const iterate = <T>(
+	collection: Record<string, T> | T[] | undefined | null,
+	fn: (value: T, key: string | number) => string,
+	inverse?: () => string,
+): string => {
+	if (Array.isArray(collection)) {
+		let result = "";
+		for (let i = 0; i < collection.length; i++) {
+			result += fn(collection[i], i);
+		}
+		return result;
+	}
+	if (collection && typeof collection === "object") {
+		let result = "";
+		for (const key of Object.keys(collection)) {
+			result += fn((collection as Record<string, T>)[key], key);
+		}
+		return result;
+	}
+	return inverse ? inverse() : "";
+};
+
+export const helpers: Helper[] = [
+	{ name: "isEmpty", category: "collection", fn: isEmpty },
+	{ name: "iterate", category: "collection", fn: iterate },
+];
+
+export { isEmpty, iterate };

--- a/test/helpers/collection.test.ts
+++ b/test/helpers/collection.test.ts
@@ -26,6 +26,9 @@ describe("isEmpty", () => {
 	it("returns true for empty object", () => {
 		expect(isEmptyFn({})).toBe(true);
 	});
+	it("returns false for non-collection values", () => {
+		expect(isEmptyFn(5)).toBe(false);
+	});
 });
 
 describe("iterate", () => {
@@ -54,5 +57,8 @@ describe("iterate", () => {
 				() => "B",
 			),
 		).toBe("B");
+	});
+	it("returns empty string when inverse is not provided", () => {
+		expect(iterateFn(undefined, () => "A")).toBe("");
 	});
 });

--- a/test/helpers/collection.test.ts
+++ b/test/helpers/collection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/collection.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("isEmpty", () => {
+	const isEmptyFn = getHelper("isEmpty");
+	it("returns true for empty array", () => {
+		expect(isEmptyFn([])).toBe(true);
+	});
+	it("returns true when no value is provided", () => {
+		expect(isEmptyFn()).toBe(true);
+	});
+	it("returns false for non-empty array", () => {
+		expect(isEmptyFn([1])).toBe(false);
+	});
+	it("returns false for non-empty object", () => {
+		expect(isEmptyFn({ foo: "bar" })).toBe(false);
+	});
+	it("returns true for empty object", () => {
+		expect(isEmptyFn({})).toBe(true);
+	});
+});
+
+describe("iterate", () => {
+	const iterateFn = getHelper("iterate");
+	it("iterates over an object", () => {
+		const obj = { a: "aaa", b: "bbb", c: "ccc" };
+		expect(iterateFn(obj, (v) => v)).toBe("aaabbbccc");
+	});
+	it("exposes keys for object iteration", () => {
+		const obj = { a: "aaa", b: "bbb", c: "ccc" };
+		expect(iterateFn(obj, (_v, key) => key)).toBe("abc");
+	});
+	it("iterates over an array", () => {
+		const arr = [{ name: "a" }, { name: "b" }, { name: "c" }];
+		expect(iterateFn(arr, (v) => v.name)).toBe("abc");
+	});
+	it("exposes index for arrays", () => {
+		const arr = [{ name: "a" }, { name: "b" }, { name: "c" }];
+		expect(iterateFn(arr, (_v, idx) => String(idx))).toBe("012");
+	});
+	it("returns inverse result for falsey collections", () => {
+		expect(
+			iterateFn(
+				undefined,
+				() => "A",
+				() => "B",
+			),
+		).toBe("B");
+	});
+});


### PR DESCRIPTION
## Summary
- convert collection helper to TypeScript and expose isEmpty & iterate helpers
- register collection helpers in HelperRegistry
- add unit tests for collection helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963bc8f16c83248f2f0c2c66e2055e