### PR TITLE
feat: add comparison helpers

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -2,6 +2,7 @@
 import type Handlebars from "handlebars";
 import { helpers as arrayHelpers } from "./helpers/array.js";
 import { helpers as codeHelpers } from "./helpers/code.js";
+import { helpers as comparisonHelpers } from "./helpers/comparison.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
@@ -39,6 +40,8 @@ export class HelperRegistry {
 		this.registerHelpers(dateHelpers);
 		// Code
 		this.registerHelpers(codeHelpers);
+		// Comparison
+		this.registerHelpers(comparisonHelpers);
 		// Markdown
 		this.registerHelpers(mdHelpers);
 	}

--- a/src/helpers/comparison.ts
+++ b/src/helpers/comparison.ts
@@ -1,0 +1,194 @@
+import type { Helper } from "../helper-registry.js";
+
+const and = (...values: unknown[]): boolean => values.every(Boolean);
+
+const compare = (a: unknown, operator: string, b: unknown): boolean => {
+	switch (operator) {
+		case "==":
+			// biome-ignore lint/suspicious/noDoubleEquals: loose comparison is required
+			return a == b;
+		case "===":
+			return a === b;
+		case "!=":
+			// biome-ignore lint/suspicious/noDoubleEquals: loose comparison is required
+			return a != b;
+		case "!==":
+			return a !== b;
+		case "<":
+			return (a as number | string) < (b as number | string);
+		case ">":
+			return (a as number | string) > (b as number | string);
+		case "<=":
+			return (a as number | string) <= (b as number | string);
+		case ">=":
+			return (a as number | string) >= (b as number | string);
+		case "typeof":
+			// biome-ignore lint/correctness/useValidTypeof: dynamic comparison
+			return typeof a === (b as string);
+		default:
+			return false;
+	}
+};
+
+const contains = (
+	collection: unknown,
+	value: unknown,
+	startIndex = 0,
+): boolean => {
+	if (Array.isArray(collection)) {
+		const col = collection as unknown[];
+		let start = startIndex;
+		if (start < 0) {
+			start = col.length + start;
+		}
+		return col.indexOf(value, start) !== -1;
+	}
+	if (typeof collection === "string" && typeof value === "string") {
+		let start = startIndex;
+		if (start < 0) {
+			start = collection.length + start;
+		}
+		return collection.indexOf(value, start) !== -1;
+	}
+	if (
+		collection &&
+		typeof collection === "object" &&
+		typeof value === "string"
+	) {
+		return value in (collection as Record<string, unknown>);
+	}
+	return false;
+};
+
+const defaultTo = (...values: unknown[]): unknown => {
+	for (const value of values) {
+		if (value != null) return value;
+	}
+	return "";
+};
+
+const eq = (a: unknown, b: unknown): boolean => a === b;
+
+const gt = (a: unknown, b: unknown): boolean =>
+	(a as number | string) > (b as number | string);
+
+const gte = (a: unknown, b: unknown): boolean =>
+	(a as number | string) >= (b as number | string);
+
+const has = (value: unknown, pattern: unknown): boolean => {
+	if (pattern === undefined) {
+		if (value == null) return false;
+		return Boolean(value);
+	}
+	if (Array.isArray(value)) {
+		return (value as unknown[]).indexOf(pattern) !== -1;
+	}
+	if (typeof value === "string" && typeof pattern === "string") {
+		return value.indexOf(pattern) !== -1;
+	}
+	if (value && typeof value === "object" && typeof pattern === "string") {
+		return pattern in (value as Record<string, unknown>);
+	}
+	return false;
+};
+
+const isFalsey = (val: unknown): boolean => !val;
+
+const isTruthy = (val: unknown): boolean => !!val;
+
+const ifEven = (num: unknown): boolean =>
+	typeof num === "number" && Number.isFinite(num) && num % 2 === 0;
+
+const ifNth = (a: unknown, b: unknown): boolean =>
+	typeof a === "number" && typeof b === "number" && b % a === 0;
+
+const ifOdd = (num: unknown): boolean =>
+	typeof num === "number" && Number.isFinite(num) && num % 2 !== 0;
+
+// biome-ignore lint/suspicious/noDoubleEquals: loose comparison is required
+const is = (a: unknown, b: unknown): boolean => a == b;
+
+// biome-ignore lint/suspicious/noDoubleEquals: loose comparison is required
+const isnt = (a: unknown, b: unknown): boolean => a != b;
+
+const lt = (a: unknown, b: unknown): boolean =>
+	(a as number | string) < (b as number | string);
+
+const lte = (a: unknown, b: unknown): boolean =>
+	(a as number | string) <= (b as number | string);
+
+const neither = (a: unknown, b: unknown): boolean => !a && !b;
+
+const not = (val: unknown): boolean => !val;
+
+const or = (...values: unknown[]): boolean => values.some(Boolean);
+
+const unlessEq = (a: unknown, b: unknown): boolean => a !== b;
+
+const unlessGt = (a: unknown, b: unknown): boolean =>
+	(a as number | string) <= (b as number | string);
+
+const unlessLt = (a: unknown, b: unknown): boolean =>
+	(a as number | string) >= (b as number | string);
+
+const unlessGteq = (a: unknown, b: unknown): boolean =>
+	(a as number | string) < (b as number | string);
+
+const unlessLteq = (a: unknown, b: unknown): boolean =>
+	(a as number | string) > (b as number | string);
+
+export const helpers: Helper[] = [
+	{ name: "and", category: "comparison", fn: and },
+	{ name: "compare", category: "comparison", fn: compare },
+	{ name: "contains", category: "comparison", fn: contains },
+	{ name: "default", category: "comparison", fn: defaultTo },
+	{ name: "eq", category: "comparison", fn: eq },
+	{ name: "gt", category: "comparison", fn: gt },
+	{ name: "gte", category: "comparison", fn: gte },
+	{ name: "has", category: "comparison", fn: has },
+	{ name: "isFalsey", category: "comparison", fn: isFalsey },
+	{ name: "isTruthy", category: "comparison", fn: isTruthy },
+	{ name: "ifEven", category: "comparison", fn: ifEven },
+	{ name: "ifNth", category: "comparison", fn: ifNth },
+	{ name: "ifOdd", category: "comparison", fn: ifOdd },
+	{ name: "is", category: "comparison", fn: is },
+	{ name: "isnt", category: "comparison", fn: isnt },
+	{ name: "lt", category: "comparison", fn: lt },
+	{ name: "lte", category: "comparison", fn: lte },
+	{ name: "neither", category: "comparison", fn: neither },
+	{ name: "not", category: "comparison", fn: not },
+	{ name: "or", category: "comparison", fn: or },
+	{ name: "unlessEq", category: "comparison", fn: unlessEq },
+	{ name: "unlessGt", category: "comparison", fn: unlessGt },
+	{ name: "unlessLt", category: "comparison", fn: unlessLt },
+	{ name: "unlessGteq", category: "comparison", fn: unlessGteq },
+	{ name: "unlessLteq", category: "comparison", fn: unlessLteq },
+];
+
+export {
+	and,
+	compare,
+	contains,
+	defaultTo,
+	eq,
+	gt,
+	gte,
+	has,
+	isFalsey,
+	isTruthy,
+	ifEven,
+	ifNth,
+	ifOdd,
+	is,
+	isnt,
+	lt,
+	lte,
+	neither,
+	not,
+	or,
+	unlessEq,
+	unlessGt,
+	unlessLt,
+	unlessGteq,
+	unlessLteq,
+};

--- a/test/helpers/comparison.test.ts
+++ b/test/helpers/comparison.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/comparison.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("comparison helpers", () => {
+	it("and/or", () => {
+		const andFn = getHelper("and");
+		const orFn = getHelper("or");
+		expect(andFn(true, 1, "a")).toBe(true);
+		expect(andFn(true, 0)).toBe(false);
+		expect(orFn(false, 0, "yes")).toBe(true);
+		expect(orFn(false, 0, "")).toBe(false);
+	});
+
+	it("compare", () => {
+		const compareFn = getHelper("compare");
+		expect(compareFn(1, "==", 1)).toBe(true);
+		expect(compareFn(1, "===", 1)).toBe(true);
+		expect(compareFn(1, "!=", 2)).toBe(true);
+		expect(compareFn(1, "!==", 2)).toBe(true);
+		expect(compareFn(1, "<", 2)).toBe(true);
+		expect(compareFn(2, ">", 1)).toBe(true);
+		expect(compareFn(1, "<=", 1)).toBe(true);
+		expect(compareFn(2, ">=", 2)).toBe(true);
+		expect(compareFn("hi", "typeof", "string")).toBe(true);
+		expect(compareFn(1, "??", 2)).toBe(false);
+	});
+
+	it("contains/default", () => {
+		const containsFn = getHelper("contains");
+		const defaultFn = getHelper("default");
+		expect(containsFn([1, 2, 3], 2)).toBe(true);
+		expect(containsFn([1, 2, 3], 1, -3)).toBe(true);
+		expect(containsFn("hello", "ell")).toBe(true);
+		expect(containsFn("hello", "ell", -4)).toBe(true);
+		expect(containsFn({ a: 1 }, "a")).toBe(true);
+		expect(containsFn({ a: 1 }, "b")).toBe(false);
+		expect(containsFn(5, "1")).toBe(false);
+		expect(defaultFn(undefined, null, "x")).toBe("x");
+		expect(defaultFn(undefined, null)).toBe("");
+	});
+
+	it("equality comparisons", () => {
+		const eqFn = getHelper("eq");
+		const gtFn = getHelper("gt");
+		const gteFn = getHelper("gte");
+		const ltFn = getHelper("lt");
+		const lteFn = getHelper("lte");
+		expect(eqFn(1, 1)).toBe(true);
+		expect(gtFn(3, 2)).toBe(true);
+		expect(gteFn(2, 2)).toBe(true);
+		expect(ltFn(1, 2)).toBe(true);
+		expect(lteFn(2, 2)).toBe(true);
+	});
+
+	it("has/isFalsey/isTruthy", () => {
+		const hasFn = getHelper("has");
+		const isFalseyFn = getHelper("isFalsey");
+		const isTruthyFn = getHelper("isTruthy");
+		expect(hasFn({ a: 1 }, "a")).toBe(true);
+		expect(hasFn([1, 2], 2)).toBe(true);
+		expect(hasFn("hello", "ell")).toBe(true);
+		expect(hasFn(null)).toBe(false);
+		expect(hasFn("hi")).toBe(true);
+		expect(hasFn(5, "1")).toBe(false);
+		expect(isFalseyFn(0)).toBe(true);
+		expect(isFalseyFn(1)).toBe(false);
+		expect(isTruthyFn("hi")).toBe(true);
+		expect(isTruthyFn("")).toBe(false);
+	});
+
+	it("ifEven/ifOdd/ifNth", () => {
+		const ifEvenFn = getHelper("ifEven");
+		const ifOddFn = getHelper("ifOdd");
+		const ifNthFn = getHelper("ifNth");
+		expect(ifEvenFn(2)).toBe(true);
+		expect(ifEvenFn(3)).toBe(false);
+		expect(ifOddFn(3)).toBe(true);
+		expect(ifOddFn(2)).toBe(false);
+		expect(ifNthFn(2, 4)).toBe(true);
+		expect(ifNthFn(2, 5)).toBe(false);
+	});
+
+	it("is/isnt", () => {
+		const isFn = getHelper("is");
+		const isntFn = getHelper("isnt");
+		expect(isFn("1", 1)).toBe(true);
+		expect(isFn("1", 2)).toBe(false);
+		expect(isntFn(1, 2)).toBe(true);
+		expect(isntFn(1, 1)).toBe(false);
+	});
+
+	it("logical helpers", () => {
+		const neitherFn = getHelper("neither");
+		const notFn = getHelper("not");
+		const unlessEqFn = getHelper("unlessEq");
+		const unlessGtFn = getHelper("unlessGt");
+		const unlessLtFn = getHelper("unlessLt");
+		const unlessGteqFn = getHelper("unlessGteq");
+		const unlessLteqFn = getHelper("unlessLteq");
+		expect(neitherFn(false, 0)).toBe(true);
+		expect(neitherFn(true, 0)).toBe(false);
+		expect(notFn(true)).toBe(false);
+		expect(notFn(false)).toBe(true);
+		expect(unlessEqFn(1, 2)).toBe(true);
+		expect(unlessEqFn(1, 1)).toBe(false);
+		expect(unlessGtFn(1, 2)).toBe(true);
+		expect(unlessGtFn(3, 2)).toBe(false);
+		expect(unlessLtFn(2, 1)).toBe(true);
+		expect(unlessLtFn(1, 2)).toBe(false);
+		expect(unlessGteqFn(1, 2)).toBe(true);
+		expect(unlessGteqFn(2, 1)).toBe(false);
+		expect(unlessLteqFn(2, 1)).toBe(true);
+		expect(unlessLteqFn(1, 2)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- port comparison helpers to TypeScript
- register comparison helpers in HelperRegistry
- add comprehensive tests to exercise all comparison helper branches for 100% coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689641060650832480db6330596ac9b9