### PR TITLE
feat: add comparison helpers in TS

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -3,6 +3,7 @@ import type Handlebars from "handlebars";
 import { helpers as arrayHelpers } from "./helpers/array.js";
 import { helpers as codeHelpers } from "./helpers/code.js";
 import { helpers as collectionHelpers } from "./helpers/collection.js";
+import { helpers as comparisonHelpers } from "./helpers/comparison.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
@@ -44,6 +45,8 @@ export class HelperRegistry {
 		this.registerHelpers(codeHelpers);
 		// Markdown
 		this.registerHelpers(mdHelpers);
+		// Comparison
+		this.registerHelpers(comparisonHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/comparison.ts
+++ b/src/helpers/comparison.ts
@@ -1,0 +1,189 @@
+// biome-ignore-all lint/suspicious/noExplicitAny lint/suspicious/noDoubleEquals: helpers accept any values
+import type { Helper } from "../helper-registry.js";
+
+const and = (...values: any[]): boolean => values.every(Boolean);
+
+const compare = (a: any, operator: string, b: any): boolean => {
+	switch (operator) {
+		case "==":
+			return a == b; // eslint-disable-line eqeqeq
+		case "===":
+			return a === b;
+		case "!=":
+			return a != b; // eslint-disable-line eqeqeq
+		case "!==":
+			return a !== b;
+		case "<":
+			return a < b;
+		case ">":
+			return a > b;
+		case "<=":
+			return a <= b;
+		case ">=":
+			return a >= b;
+		case "typeof":
+			return typeof a === b;
+		default:
+			throw new Error(`helper {{compare}}: invalid operator: '${operator}'`);
+	}
+};
+
+const contains = (collection: any, value: any, startIndex = 0): boolean => {
+	if (collection == null) return false;
+	if (typeof collection === "string" || Array.isArray(collection)) {
+		return collection.indexOf(value, startIndex) > -1;
+	}
+	if (typeof collection === "object") {
+		return value in collection;
+	}
+	return false;
+};
+
+const defaultHelper = (...values: any[]): any => {
+	for (const val of values) {
+		if (val != null) return val;
+	}
+	return "";
+};
+
+const eq = (a: any, b: any): boolean => a === b;
+
+const gt = (a: any, b: any): boolean => a > b;
+
+const gte = (a: any, b: any): boolean => a >= b;
+
+const has = (value: any, pattern: any): boolean => {
+	if (value == null || pattern == null) return false;
+	if (Array.isArray(value) || typeof value === "string") {
+		return value.indexOf(pattern) > -1;
+	}
+	if (typeof value === "object") {
+		return pattern in value;
+	}
+	return false;
+};
+
+const falsey = (val: any, keywords?: string | string[]): boolean => {
+	if (!val) return true;
+	const words: string[] = Array.isArray(keywords)
+		? keywords
+		: keywords != null
+			? [keywords]
+			: [
+					"0",
+					"false",
+					"nada",
+					"nil",
+					"nay",
+					"nah",
+					"negative",
+					"no",
+					"none",
+					"nope",
+					"nul",
+					"null",
+					"nix",
+					"nyet",
+					"uh-uh",
+					"veto",
+					"zero",
+				];
+	const lower = typeof val === "string" ? val.toLowerCase() : null;
+	for (const word of words) {
+		if (word === val) return true;
+		if (lower != null && word === lower) return true;
+	}
+	return false;
+};
+
+const isFalsey = (val: any): boolean => falsey(val);
+
+const isTruthy = (val: any): boolean => !falsey(val);
+
+const ifEven = (num: any): boolean => typeof num === "number" && num % 2 === 0;
+
+const ifNth = (a: any, b: any): boolean =>
+	typeof a === "number" && typeof b === "number" && b % a === 0;
+
+const ifOdd = (val: any): boolean =>
+	typeof val === "number" && Math.abs(val % 2) === 1;
+
+const is = (a: any, b: any): boolean => a == b; // eslint-disable-line eqeqeq
+
+const isnt = (a: any, b: any): boolean => a != b; // eslint-disable-line eqeqeq
+
+const lt = (a: any, b: any): boolean => a < b;
+
+const lte = (a: any, b: any): boolean => a <= b;
+
+const neither = (a: any, b: any): boolean => !a && !b;
+
+const not = (val: any): boolean => !val;
+
+const or = (...values: any[]): boolean => values.some(Boolean);
+
+const unlessEq = (a: any, b: any): boolean => a !== b;
+
+const unlessGt = (a: any, b: any): boolean => a <= b;
+
+const unlessLt = (a: any, b: any): boolean => a >= b;
+
+const unlessGteq = (a: any, b: any): boolean => a < b;
+
+const unlessLteq = (a: any, b: any): boolean => a > b;
+
+export const helpers: Helper[] = [
+	{ name: "and", category: "comparison", fn: and },
+	{ name: "compare", category: "comparison", fn: compare },
+	{ name: "contains", category: "comparison", fn: contains },
+	{ name: "default", category: "comparison", fn: defaultHelper },
+	{ name: "eq", category: "comparison", fn: eq },
+	{ name: "gt", category: "comparison", fn: gt },
+	{ name: "gte", category: "comparison", fn: gte },
+	{ name: "has", category: "comparison", fn: has },
+	{ name: "isFalsey", category: "comparison", fn: isFalsey },
+	{ name: "isTruthy", category: "comparison", fn: isTruthy },
+	{ name: "ifEven", category: "comparison", fn: ifEven },
+	{ name: "ifNth", category: "comparison", fn: ifNth },
+	{ name: "ifOdd", category: "comparison", fn: ifOdd },
+	{ name: "is", category: "comparison", fn: is },
+	{ name: "isnt", category: "comparison", fn: isnt },
+	{ name: "lt", category: "comparison", fn: lt },
+	{ name: "lte", category: "comparison", fn: lte },
+	{ name: "neither", category: "comparison", fn: neither },
+	{ name: "not", category: "comparison", fn: not },
+	{ name: "or", category: "comparison", fn: or },
+	{ name: "unlessEq", category: "comparison", fn: unlessEq },
+	{ name: "unlessGt", category: "comparison", fn: unlessGt },
+	{ name: "unlessLt", category: "comparison", fn: unlessLt },
+	{ name: "unlessGteq", category: "comparison", fn: unlessGteq },
+	{ name: "unlessLteq", category: "comparison", fn: unlessLteq },
+];
+
+export {
+	and,
+	compare,
+	contains,
+	defaultHelper as default,
+	eq,
+	gt,
+	gte,
+	has,
+	isFalsey,
+	isTruthy,
+	ifEven,
+	ifNth,
+	ifOdd,
+	is,
+	isnt,
+	lt,
+	lte,
+	neither,
+	not,
+	or,
+	unlessEq,
+	unlessGt,
+	unlessLt,
+	unlessGteq,
+	unlessLteq,
+};

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -13,6 +13,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("after")).toBeTruthy();
 	});
+	test("includes comparison helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("and")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/comparison.test.ts
+++ b/test/helpers/comparison.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/comparison.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("and", () => {
+	const fn = getHelper("and");
+	it("returns true when all values are truthy", () => {
+		expect(fn(true, 1, "foo")).toBe(true);
+	});
+	it("returns false when any value is falsy", () => {
+		expect(fn(true, 0, "foo")).toBe(false);
+	});
+});
+
+describe("compare", () => {
+	const fn = getHelper("compare");
+	it("supports == operator", () => {
+		expect(fn("5", "==", 5)).toBe(true);
+	});
+	it("supports >= operator", () => {
+		expect(fn(3, ">=", 5)).toBe(false);
+	});
+});
+
+describe("contains", () => {
+	const fn = getHelper("contains");
+	it("detects values in strings", () => {
+		expect(fn("abc", "b")).toBe(true);
+		expect(fn("abc", "z")).toBe(false);
+	});
+	it("detects values in arrays", () => {
+		expect(fn([1, 2, 3], 2)).toBe(true);
+		expect(fn([1, 2, 3], 4)).toBe(false);
+	});
+});
+
+describe("default", () => {
+	const fn = getHelper("default");
+	it("returns first non-nullish value", () => {
+		expect(fn(undefined, null, "a", "b")).toBe("a");
+		expect(fn(undefined, null)).toBe("");
+	});
+});
+
+describe("comparison basics", () => {
+	it("eq", () => {
+		const fn = getHelper("eq");
+		expect(fn(1, 1)).toBe(true);
+	});
+	it("gt and gte", () => {
+		const gt = getHelper("gt");
+		const gte = getHelper("gte");
+		expect(gt(5, 3)).toBe(true);
+		expect(gte(3, 3)).toBe(true);
+	});
+	it("lt and lte", () => {
+		const lt = getHelper("lt");
+		const lte = getHelper("lte");
+		expect(lt(1, 3)).toBe(true);
+		expect(lte(3, 3)).toBe(true);
+	});
+});
+
+describe("utility helpers", () => {
+	it("has", () => {
+		const fn = getHelper("has");
+		expect(fn([1, 2, 3], 2)).toBe(true);
+		expect(fn({ a: 1 }, "a")).toBe(true);
+		expect(fn({ a: 1 }, "b")).toBe(false);
+	});
+	it("isFalsey/isTruthy", () => {
+		const isFalsey = getHelper("isFalsey");
+		const isTruthy = getHelper("isTruthy");
+		expect(isFalsey(0)).toBe(true);
+		expect(isTruthy(1)).toBe(true);
+	});
+	it("ifEven/ifOdd", () => {
+		const ifEven = getHelper("ifEven");
+		const ifOdd = getHelper("ifOdd");
+		expect(ifEven(2)).toBe(true);
+		expect(ifOdd(3)).toBe(true);
+	});
+	it("ifNth", () => {
+		const ifNth = getHelper("ifNth");
+		expect(ifNth(2, 4)).toBe(true);
+		expect(ifNth(3, 4)).toBe(false);
+	});
+	it("is/isnt", () => {
+		const is = getHelper("is");
+		const isnt = getHelper("isnt");
+		expect(is("1", 1)).toBe(true);
+		expect(isnt("1", 1)).toBe(false);
+	});
+	it("neither", () => {
+		const fn = getHelper("neither");
+		expect(fn(false, 0)).toBe(true);
+		expect(fn(true, 0)).toBe(false);
+	});
+	it("not", () => {
+		const fn = getHelper("not");
+		expect(fn(true)).toBe(false);
+	});
+	it("or", () => {
+		const fn = getHelper("or");
+		expect(fn(false, 0, "a")).toBe(true);
+		expect(fn(false, 0, "")).toBe(false);
+	});
+	it("unless helpers", () => {
+		const unlessEq = getHelper("unlessEq");
+		const unlessGt = getHelper("unlessGt");
+		const unlessLt = getHelper("unlessLt");
+		const unlessGteq = getHelper("unlessGteq");
+		const unlessLteq = getHelper("unlessLteq");
+		expect(unlessEq(1, 2)).toBe(true);
+		expect(unlessGt(1, 2)).toBe(true);
+		expect(unlessLt(2, 1)).toBe(true);
+		expect(unlessGteq(1, 2)).toBe(true);
+		expect(unlessLteq(2, 1)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- add TypeScript comparison helper suite
- register comparison helpers in helper registry
- cover comparison helpers with vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964c8555748324b5ead9c096ca429c