### PR TITLE
feat: add fs helper functions

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -5,6 +5,7 @@ import { helpers as codeHelpers } from "./helpers/code.js";
 import { helpers as collectionHelpers } from "./helpers/collection.js";
 import { helpers as comparisonHelpers } from "./helpers/comparison.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
+import { helpers as fsHelpers } from "./helpers/fs.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -41,6 +42,8 @@ export class HelperRegistry {
 		this.registerHelpers(collectionHelpers);
 		// Date
 		this.registerHelpers(dateHelpers);
+		// File System
+		this.registerHelpers(fsHelpers);
 		// Code
 		this.registerHelpers(codeHelpers);
 		// Markdown

--- a/src/helpers/fs.ts
+++ b/src/helpers/fs.ts
@@ -1,0 +1,80 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
+import fs from "node:fs";
+import path from "node:path";
+import isGlob from "is-glob";
+import micromatch from "micromatch";
+import type { Helper } from "../helper-registry.js";
+
+const fileSize = (value: unknown, precision?: unknown): string => {
+	if (value == null) return "0 B";
+
+	const number =
+		typeof value === "number"
+			? value
+			: ((value as { length?: number }).length ?? 0);
+	if (!number) return "0 B";
+
+	const precisionNumber = typeof precision === "number" ? precision : 2;
+	const abbr = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+	const factor = 10 ** precisionNumber;
+	let i = abbr.length - 1;
+	do {
+		const size = 10 ** (i * 3);
+		if (size <= number + 1) {
+			const num = Math.round((number * factor) / size) / factor;
+			return `${num} ${abbr[i]}`;
+		}
+		/* c8 ignore next */
+	} while (--i >= 0);
+	/* c8 ignore next 2 */
+	return `${number} B`;
+};
+
+const read = (filepath: string): string => {
+	return fs.readFileSync(filepath, "utf8");
+};
+
+const isOptions = (value: unknown): boolean => {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"hash" in (value as Record<string, unknown>),
+	);
+};
+
+type Filter = ((files: string[]) => string[]) | RegExp | string | undefined;
+
+const readdir = (
+	dir: string,
+	filter?: Filter | Record<string, unknown>,
+): string[] => {
+	const files = fs.readdirSync(dir).map((fp) => path.join(dir, fp));
+	const filterArg = isOptions(filter) ? undefined : (filter as Filter);
+
+	if (typeof filterArg === "function") {
+		return filterArg(files);
+	}
+	if (filterArg instanceof RegExp) {
+		return files.filter((fp) => filterArg.test(fp));
+	}
+	if (typeof filterArg === "string") {
+		if (isGlob(filterArg)) {
+			return micromatch(files, filterArg);
+		}
+		if (filterArg === "isFile" || filterArg === "isDirectory") {
+			return files.filter((fp) => {
+				const stat = fs.statSync(fp);
+				return filterArg === "isFile" ? stat.isFile() : stat.isDirectory();
+			});
+		}
+	}
+	return files;
+};
+
+export const helpers: Helper[] = [
+	{ name: "fileSize", category: "fs", fn: fileSize as any },
+	{ name: "read", category: "fs", fn: read as any },
+	{ name: "readdir", category: "fs", fn: readdir as any },
+];
+
+export { fileSize, read, readdir };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -17,6 +17,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("and")).toBeTruthy();
 	});
+	test("includes fs helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("read")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/fs.test.ts
+++ b/test/helpers/fs.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/fs.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+const readFn = getHelper("read");
+const readdirFn = getHelper("readdir");
+const fileSizeFn = getHelper("fileSize");
+
+const libDir = path.join("helpers", "lib");
+const libFiles = fs.readdirSync(libDir).map((fp) => path.join(libDir, fp));
+
+describe("fileSize", () => {
+	it("formats numbers as bytes", () => {
+		expect(fileSizeFn(13661855)).toBe("13.66 MB");
+	});
+	it("uses string length when not a number", () => {
+		expect(fileSizeFn("foo")).toBe("3 B");
+	});
+	it("returns 0 B for empty values", () => {
+		expect(fileSizeFn(undefined)).toBe("0 B");
+		expect(fileSizeFn("")).toBe("0 B");
+		expect(fileSizeFn({})).toBe("0 B");
+	});
+	it("respects precision argument", () => {
+		expect(fileSizeFn(1396, 1)).toBe("1.4 kB");
+	});
+});
+
+describe("read", () => {
+	it("reads file contents", () => {
+		const result = readFn("helpers/test/fixtures/read/a.txt");
+		expect(result).toBe("abc");
+	});
+});
+
+describe("readdir", () => {
+	it("returns files in a directory", () => {
+		expect(readdirFn(libDir)).toEqual(libFiles);
+	});
+	it("ignores options object", () => {
+		expect(readdirFn(libDir, { hash: {} })).toEqual(libFiles);
+	});
+	it("filters with a custom function", () => {
+		const fn = (arr: string[]) => arr.filter((fp) => fp.endsWith(".js"));
+		expect(readdirFn(libDir, fn)).toEqual(
+			libFiles.filter((fp) => fp.endsWith(".js")),
+		);
+	});
+	it("filters with a regex", () => {
+		expect(readdirFn(libDir, /\.js$/)).toEqual(
+			libFiles.filter((fp) => fp.endsWith(".js")),
+		);
+	});
+	it("filters with a glob", () => {
+		expect(readdirFn(libDir, "helpers/lib/[a-d]*.js")).toEqual(
+			libFiles.filter((fp) => /helpers\/lib\/[a-d].*\.js$/.test(fp)),
+		);
+	});
+	it("filters by stat isFile", () => {
+		expect(readdirFn(libDir, "isFile")).toEqual(
+			libFiles.filter((fp) => fs.statSync(fp).isFile()),
+		);
+	});
+	it("filters by stat isDirectory", () => {
+		expect(readdirFn(libDir, "isDirectory")).toEqual(
+			libFiles.filter((fp) => fs.statSync(fp).isDirectory()),
+		);
+	});
+	it("returns all files for invalid filter", () => {
+		expect(readdirFn(libDir, "foo")).toEqual(libFiles);
+	});
+});


### PR DESCRIPTION
## Summary
- add TypeScript fs helper with fileSize, read, and readdir helpers
- register fs helpers within the helper registry
- test fs helpers with full coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896531d35c48324b7326c0566b47420