### PR TITLE
feat: migrate html helper to typescript

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -6,6 +6,7 @@ import { helpers as collectionHelpers } from "./helpers/collection.js";
 import { helpers as comparisonHelpers } from "./helpers/comparison.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as fsHelpers } from "./helpers/fs.js";
+import { helpers as htmlHelpers } from "./helpers/html.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -48,6 +49,8 @@ export class HelperRegistry {
 		this.registerHelpers(codeHelpers);
 		// Markdown
 		this.registerHelpers(mdHelpers);
+		// Html
+		this.registerHelpers(htmlHelpers);
 		// Comparison
 		this.registerHelpers(comparisonHelpers);
 	}

--- a/src/helpers/comparison.ts
+++ b/src/helpers/comparison.ts
@@ -169,6 +169,7 @@ export {
 	gt,
 	gte,
 	has,
+	falsey,
 	isFalsey,
 	isTruthy,
 	ifEven,

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,0 +1,157 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: handlebars helpers use any for context
+import path from "node:path";
+import tag from "html-tag";
+import striptags from "striptags";
+import type { Helper } from "../helper-registry.js";
+import { arrayify } from "./array.js";
+
+const parseAttributes = (hash: Record<string, unknown> = {}): string =>
+	Object.keys(hash)
+		.map((key) => `${key}="${String(hash[key]).replace(/^['"]|["']$/g, "")}"`)
+		.join(" ");
+
+const attr = (
+	options: { hash?: Record<string, unknown> } | undefined,
+): string => {
+	const val = parseAttributes(options?.hash ?? {});
+	return val.trim() ? ` ${val}` : "";
+};
+
+const css = function (
+	this: any,
+	list?: string | string[],
+	options?: { hash?: Record<string, unknown> },
+): string {
+	// biome-ignore lint/complexity/noArguments: to match handlebars helper signature
+	if (arguments.length < 2) {
+		options = list as any;
+		list = [];
+	}
+	let styles = arrayify(list ?? []);
+	let assets = "";
+	if (this && this.options) {
+		assets = this.options.assets || "";
+	}
+	if (options?.hash?.href) {
+		styles = arrayify(options.hash.href as string | string[]);
+	}
+	return styles
+		.map((item) => {
+			const ext = path.extname(item);
+			let fp = item;
+			if (!/(^\/\/)|(:\/\/)/.test(item)) {
+				fp = path.posix.join(assets, item);
+			}
+			if (ext === ".less") {
+				return `<link type="text/css" rel="stylesheet/less" href="${fp}">`;
+			}
+			return `<link type="text/css" rel="stylesheet" href="${fp}">`;
+		})
+		.join("\n");
+};
+
+const js = (context: any): string => {
+	if (context && typeof context === "object" && !Array.isArray(context)) {
+		const attrStr = parseAttributes(context.hash ?? {});
+		return `<script${attrStr ? ` ${attrStr}` : ""}></script>`;
+	}
+	if (typeof context === "string") {
+		return `<script src="${context}"></script>`;
+	}
+	const items = arrayify(context);
+	return items
+		.map((fp) =>
+			path.extname(fp) === ".coffee"
+				? tag("script", { type: "text/coffeescript", src: fp })
+				: tag("script", { src: fp }),
+		)
+		.join("\n");
+};
+
+const sanitize = (str?: string): string => {
+	if (typeof str !== "string") return "";
+	return striptags(str).trim();
+};
+
+const ul = (
+	context: any[],
+	options: { hash?: Record<string, unknown>; fn: (item: any) => string },
+): string => {
+	const attrs = parseAttributes(options.hash ?? {});
+	const items = context.map((item) =>
+		typeof item === "string" ? item : options.fn(item),
+	);
+	const open = attrs ? `<ul ${attrs}>` : "<ul>";
+	return `${open}${items.map((i) => `<li>${i}</li>`).join("\n")}</ul>`;
+};
+
+const ol = (
+	context: any[],
+	options: { hash?: Record<string, unknown>; fn: (item: any) => string },
+): string => {
+	const attrs = parseAttributes(options.hash ?? {});
+	const items = context.map((item) =>
+		typeof item === "string" ? item : options.fn(item),
+	);
+	const open = attrs ? `<ol ${attrs}>` : "<ol>";
+	return `${open}${items.map((i) => `<li>${i}</li>`).join("\n")}</ol>`;
+};
+
+type ThumbnailContext = {
+	id: string;
+	alt: string;
+	thumbnail: string;
+	size: { width: number; height: number };
+	full?: string;
+	classes?: { image?: string[]; figure?: string[]; link?: string[] };
+	caption?: string;
+};
+
+const thumbnailImage = (context: ThumbnailContext): string => {
+	let figure = "";
+	let image = "";
+	const link = context.full || false;
+	const imageAttributes: Record<string, any> = {
+		alt: context.alt,
+		src: context.thumbnail,
+		width: context.size.width,
+		height: context.size.height,
+	};
+	const figureAttributes: Record<string, any> = { id: `image-${context.id}` };
+	const linkAttributes: Record<string, any> = { href: link, rel: "thumbnail" };
+	if (context.classes) {
+		if (context.classes.image) {
+			imageAttributes.class = context.classes.image.join(" ");
+		}
+		if (context.classes.figure) {
+			figureAttributes.class = context.classes.figure.join(" ");
+		}
+		if (context.classes.link) {
+			linkAttributes.class = context.classes.link.join(" ");
+		}
+	}
+	figure += `<figure ${parseAttributes(figureAttributes)}>\n`;
+	image += `<img ${parseAttributes(imageAttributes)}>\n`;
+	if (link) {
+		figure += `<a ${parseAttributes(linkAttributes)}>\n${image}</a>\n`;
+	} else {
+		figure += image;
+	}
+	if (context.caption) {
+		figure += `<figcaption>${context.caption}</figcaption>\n`;
+	}
+	figure += "</figure>";
+	return figure;
+};
+
+export const helpers: Helper[] = [
+	{ name: "attr", category: "html", fn: attr },
+	{ name: "css", category: "html", fn: css },
+	{ name: "js", category: "html", fn: js },
+	{ name: "sanitize", category: "html", fn: sanitize },
+	{ name: "ul", category: "html", fn: ul },
+	{ name: "ol", category: "html", fn: ol },
+	{ name: "thumbnailImage", category: "html", fn: thumbnailImage },
+];
+
+export { attr, css, js, sanitize, ul, ol, thumbnailImage };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -21,6 +21,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("read")).toBeTruthy();
 	});
+	test("includes html helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("attr")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/html.test.ts
+++ b/test/helpers/html.test.ts
@@ -16,6 +16,9 @@ describe("attr", () => {
 		expect(attrFn({ hash: { class: "btn" } })).toBe(' class="btn"');
 		expect(attrFn({ hash: {} })).toBe("");
 	});
+	it("handles undefined options", () => {
+		expect(attrFn()).toBe("");
+	});
 });
 
 describe("css", () => {

--- a/test/helpers/html.test.ts
+++ b/test/helpers/html.test.ts
@@ -1,0 +1,172 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests can use any types
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/html.js";
+
+type HelperFn = (...args: any[]) => any;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("attr", () => {
+	const attrFn = getHelper("attr");
+	it("stringifies hash attributes", () => {
+		expect(attrFn({ hash: { class: "btn" } })).toBe(' class="btn"');
+		expect(attrFn({ hash: {} })).toBe("");
+	});
+});
+
+describe("css", () => {
+	const cssFn = getHelper("css");
+	it("returns empty string when no styles", () => {
+		expect(cssFn.call({})).toBe("");
+	});
+	it("uses a path passed as string", () => {
+		expect(cssFn.call({}, "abc.css", { hash: {} })).toBe(
+			'<link type="text/css" rel="stylesheet" href="abc.css">',
+		);
+	});
+	it("uses options.assets", () => {
+		expect(
+			cssFn.call({ options: { assets: "foo" } }, "abc.css", { hash: {} }),
+		).toBe('<link type="text/css" rel="stylesheet" href="foo/abc.css">');
+	});
+	it("uses the href attribute", () => {
+		expect(cssFn.call({}, { hash: { href: "abc.css" } })).toBe(
+			'<link type="text/css" rel="stylesheet" href="abc.css">',
+		);
+	});
+	it("creates multiple tags", () => {
+		expect(cssFn.call({}, ["a.css", "bcss", "c.css"], { hash: {} })).toBe(
+			[
+				'<link type="text/css" rel="stylesheet" href="a.css">',
+				'<link type="text/css" rel="stylesheet" href="bcss">',
+				'<link type="text/css" rel="stylesheet" href="c.css">',
+			].join("\n"),
+		);
+	});
+	it("creates a less tag", () => {
+		expect(cssFn.call({}, ["a.less"], { hash: {} })).toBe(
+			'<link type="text/css" rel="stylesheet/less" href="a.less">',
+		);
+	});
+});
+
+describe("js", () => {
+	const jsFn = getHelper("js");
+	it("creates an empty script tag", () => {
+		expect(jsFn({ hash: {} })).toBe("<script></script>");
+	});
+	it("uses a path passed as string", () => {
+		expect(jsFn("abc.js")).toBe('<script src="abc.js"></script>');
+	});
+	it("uses the src attribute", () => {
+		expect(jsFn({ hash: { src: "abc.js" } })).toBe(
+			'<script src="abc.js"></script>',
+		);
+	});
+	it("creates multiple tags", () => {
+		expect(jsFn(["a.js", "bjs", "c.js"])).toBe(
+			[
+				'<script src="a.js"></script>',
+				'<script src="bjs"></script>',
+				'<script src="c.js"></script>',
+			].join("\n"),
+		);
+	});
+	it("creates a coffeescript tag", () => {
+		expect(jsFn(["a.coffee"])).toBe(
+			'<script type="text/coffeescript" src="a.coffee"></script>',
+		);
+	});
+});
+
+describe("sanitize", () => {
+	const sanitizeFn = getHelper("sanitize");
+	it("returns empty string for undefined", () => {
+		expect(sanitizeFn()).toBe("");
+	});
+	it("strips html from a string", () => {
+		expect(sanitizeFn("<span>foo</span>")).toBe("foo");
+	});
+});
+
+describe("ul", () => {
+	const ulFn = getHelper("ul");
+	const data = [
+		{ aaa: "AAA", bbb: "BBB" },
+		{ aaa: "CCC", bbb: "DDD" },
+	];
+	it("creates an unordered list", () => {
+		const result = ulFn(data, {
+			hash: { class: "names" },
+			fn: (item: any) => `${item.aaa} ${item.bbb}`,
+		});
+		expect(result).toBe(
+			'<ul class="names"><li>AAA BBB</li>\n<li>CCC DDD</li></ul>',
+		);
+	});
+});
+
+describe("ol", () => {
+	const olFn = getHelper("ol");
+	const data = [
+		{ aaa: "AAA", bbb: "BBB" },
+		{ aaa: "CCC", bbb: "DDD" },
+	];
+	it("creates an ordered list", () => {
+		const result = olFn(data, {
+			hash: { class: "names" },
+			fn: (item: any) => `${item.aaa} ${item.bbb}`,
+		});
+		expect(result).toBe(
+			'<ol class="names"><li>AAA BBB</li>\n<li>CCC DDD</li></ol>',
+		);
+	});
+});
+
+describe("thumbnailImage", () => {
+	const thumbnailFn = getHelper("thumbnailImage");
+	it("returns figure with link and caption", () => {
+		const context = {
+			id: "id",
+			alt: "Picture of a placeholder",
+			thumbnail: "http://placehold.it/200x200/0eafff/ffffff.png",
+			size: { width: 200, height: 200 },
+			full: "http://placehold.it/600x400/0eafff/ffffff.png",
+			classes: {
+				figure: ["test"],
+				image: ["test"],
+				link: ["test"],
+			},
+			caption: "My new caption!",
+		};
+		const comparison = [
+			'<figure id="image-id" class="test">',
+			'<a href="http://placehold.it/600x400/0eafff/ffffff.png" rel="thumbnail" class="test">',
+			'<img alt="Picture of a placeholder" src="http://placehold.it/200x200/0eafff/ffffff.png" width="200" height="200" class="test">',
+			"</a>",
+			"<figcaption>My new caption!</figcaption>",
+			"</figure>",
+		].join("\n");
+		expect(thumbnailFn(context)).toBe(comparison);
+	});
+	it("returns figure without link", () => {
+		const context = {
+			id: "id",
+			alt: "Picture of a placeholder",
+			thumbnail: "http://placehold.it/200x200/0eafff/ffffff.png",
+			size: { width: 200, height: 200 },
+			caption: "My new caption!",
+		};
+		const comparison = [
+			'<figure id="image-id">',
+			'<img alt="Picture of a placeholder" src="http://placehold.it/200x200/0eafff/ffffff.png" width="200" height="200">',
+			"<figcaption>My new caption!</figcaption>",
+			"</figure>",
+		].join("\n");
+		expect(thumbnailFn(context)).toBe(comparison);
+	});
+});

--- a/test/helpers/html.test.ts
+++ b/test/helpers/html.test.ts
@@ -26,6 +26,9 @@ describe("css", () => {
 	it("returns empty string when no styles", () => {
 		expect(cssFn.call({})).toBe("");
 	});
+	it("handles undefined list with options", () => {
+		expect(cssFn.call({}, undefined, { hash: {} })).toBe("");
+	});
 	it("uses a path passed as string", () => {
 		expect(cssFn.call({}, "abc.css", { hash: {} })).toBe(
 			'<link type="text/css" rel="stylesheet" href="abc.css">',
@@ -35,6 +38,11 @@ describe("css", () => {
 		expect(
 			cssFn.call({ options: { assets: "foo" } }, "abc.css", { hash: {} }),
 		).toBe('<link type="text/css" rel="stylesheet" href="foo/abc.css">');
+	});
+	it("falls back when assets option missing", () => {
+		expect(cssFn.call({ options: {} }, "abc.css", { hash: {} })).toBe(
+			'<link type="text/css" rel="stylesheet" href="abc.css">',
+		);
 	});
 	it("uses the href attribute", () => {
 		expect(cssFn.call({}, { hash: { href: "abc.css" } })).toBe(
@@ -61,6 +69,9 @@ describe("js", () => {
 	const jsFn = getHelper("js");
 	it("creates an empty script tag", () => {
 		expect(jsFn({ hash: {} })).toBe("<script></script>");
+	});
+	it("handles object without hash", () => {
+		expect(jsFn({})).toBe("<script></script>");
 	});
 	it("uses a path passed as string", () => {
 		expect(jsFn("abc.js")).toBe('<script src="abc.js"></script>');
@@ -111,6 +122,10 @@ describe("ul", () => {
 			'<ul class="names"><li>AAA BBB</li>\n<li>CCC DDD</li></ul>',
 		);
 	});
+	it("handles string items without attributes", () => {
+		const result = ulFn(["A", "B"], { fn: (i: any) => i });
+		expect(result).toBe("<ul><li>A</li>\n<li>B</li></ul>");
+	});
 });
 
 describe("ol", () => {
@@ -127,6 +142,10 @@ describe("ol", () => {
 		expect(result).toBe(
 			'<ol class="names"><li>AAA BBB</li>\n<li>CCC DDD</li></ol>',
 		);
+	});
+	it("handles string items without attributes", () => {
+		const result = olFn(["A", "B"], { fn: (i: any) => i });
+		expect(result).toBe("<ol><li>A</li>\n<li>B</li></ol>");
 	});
 });
 


### PR DESCRIPTION
## Summary
- convert html helper to TypeScript
- register html helpers
- add tests for html helpers and registry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68965f3fa1648324bb4d34c512b88200