### PR TITLE
feat: add i18n helper

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -7,6 +7,7 @@ import { helpers as comparisonHelpers } from "./helpers/comparison.js";
 import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as fsHelpers } from "./helpers/fs.js";
 import { helpers as htmlHelpers } from "./helpers/html.js";
+import { helpers as i18nHelpers } from "./helpers/i18n.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -53,6 +54,8 @@ export class HelperRegistry {
 		this.registerHelpers(htmlHelpers);
 		// Comparison
 		this.registerHelpers(comparisonHelpers);
+		// i18n
+		this.registerHelpers(i18nHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/i18n.ts
+++ b/src/helpers/i18n.ts
@@ -1,0 +1,57 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: handlebars helpers use any
+import get from "get-value";
+import type { Helper } from "../helper-registry.js";
+
+const i18n = function (
+	this: any,
+	prop: unknown,
+	locals?: any,
+	options?: { hash?: Record<string, unknown> },
+): string {
+	if (
+		locals &&
+		typeof locals === "object" &&
+		"hash" in locals &&
+		options === undefined
+	) {
+		options = locals;
+		locals = {};
+	}
+
+	if (typeof prop !== "string") {
+		throw new Error('{{i18n}} helper expected "key" to be a string');
+	}
+
+	const context = {
+		...this,
+		...(locals as Record<string, unknown>),
+		...(options?.hash ?? {}),
+	} as Record<string, unknown>;
+
+	const lang = context.language || context.lang;
+	if (typeof lang !== "string") {
+		throw new TypeError('{{i18n}} helper expected "language" to be a string');
+	}
+
+	const cache = (context as Record<string, unknown>)[lang];
+	if (typeof cache === "undefined") {
+		throw new Error(`{{i18n}} helper cannot find language "${lang}"`);
+	}
+
+	const result = get(cache, prop as any);
+	if (typeof result === "undefined") {
+		throw new Error(
+			'{{i18n}} helper cannot find property "' +
+				String(prop) +
+				'" for language "' +
+				lang +
+				'"',
+		);
+	}
+
+	return String(result);
+};
+
+export const helpers: Helper[] = [{ name: "i18n", category: "i18n", fn: i18n }];
+
+export { i18n };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -25,6 +25,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("attr")).toBeTruthy();
 	});
+	test("includes i18n helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("i18n")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/i18n.test.ts
+++ b/test/helpers/i18n.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/i18n.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("i18n", () => {
+	const i18nFn = getHelper("i18n");
+
+	it("returns translation for language", () => {
+		const context = { language: "en", en: { hello: "hi" } };
+		expect(i18nFn.call(context, "hello")).toBe("hi");
+	});
+
+	it("handles lang alias and options", () => {
+		const context = { lang: "en", en: { greet: "hey" } };
+		expect(i18nFn.call(context, "greet", { hash: {} })).toBe("hey");
+	});
+
+	it("throws when key is not string", () => {
+		const context = { language: "en", en: { foo: "bar" } };
+		expect(() => i18nFn.call(context, 123 as unknown as never)).toThrow();
+	});
+
+	it("throws when language is not string", () => {
+		const context = { language: 10 as unknown as never, en: { foo: "bar" } };
+		expect(() => i18nFn.call(context, "foo")).toThrow();
+	});
+
+	it("throws when language not found", () => {
+		const context = { language: "fr", en: { foo: "bar" } };
+		expect(() => i18nFn.call(context, "foo")).toThrow();
+	});
+
+	it("throws when property not found", () => {
+		const context = { language: "en", en: { other: "bar" } };
+		expect(() => i18nFn.call(context, "foo")).toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
- add i18n helper in TypeScript
- register i18n helper in HelperRegistry
- add unit tests for i18n helper

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68966c560bac832498371a77625ecceb