### PR TITLE
feat: add inflection helpers

### DIFF
--- a/site/docs/migration-progress.md
+++ b/site/docs/migration-progress.md
@@ -29,7 +29,7 @@ We are working to migrate all legacy helpers to a modern helper approach with le
 | `fs` | No |
 | `html` | No |
 | `i18n` | No |
-| `inflection` | No |
+| `inflection` | ✅ |
 | `logging` | No |
 | `markdown` | ✅ |
 | `match` | No |

--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -8,6 +8,7 @@ import { helpers as dateHelpers } from "./helpers/date.js";
 import { helpers as fsHelpers } from "./helpers/fs.js";
 import { helpers as htmlHelpers } from "./helpers/html.js";
 import { helpers as i18nHelpers } from "./helpers/i18n.js";
+import { helpers as inflectionHelpers } from "./helpers/inflection.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -56,6 +57,8 @@ export class HelperRegistry {
 		this.registerHelpers(comparisonHelpers);
 		// i18n
 		this.registerHelpers(i18nHelpers);
+		// Inflection
+		this.registerHelpers(inflectionHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/inflection.ts
+++ b/src/helpers/inflection.ts
@@ -1,0 +1,39 @@
+import type { Helper } from "../helper-registry.js";
+
+const inflect = (
+	count: number,
+	singular: string,
+	plural: string,
+	includeCount?: boolean,
+): string => {
+	const word = count > 1 || count === 0 ? plural : singular;
+	return includeCount ? `${count} ${word}` : word;
+};
+
+const ordinalize = (value: number | string): string => {
+	const num = Math.abs(Math.round(Number(value)));
+	const str = String(value);
+	const res = num % 100;
+
+	if ([11, 12, 13].includes(res)) {
+		return `${str}th`;
+	}
+
+	switch (num % 10) {
+		case 1:
+			return `${str}st`;
+		case 2:
+			return `${str}nd`;
+		case 3:
+			return `${str}rd`;
+		default:
+			return `${str}th`;
+	}
+};
+
+export const helpers: Helper[] = [
+	{ name: "inflect", category: "inflection", fn: inflect },
+	{ name: "ordinalize", category: "inflection", fn: ordinalize },
+];
+
+export { inflect, ordinalize };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -29,6 +29,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("i18n")).toBeTruthy();
 	});
+	test("includes inflection helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("inflect")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/inflection.test.ts
+++ b/test/helpers/inflection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/inflection.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("inflect", () => {
+	const inflectFn = getHelper("inflect");
+	it("returns singular for count 1", () => {
+		expect(inflectFn(1, "apple", "apples")).toBe("apple");
+	});
+	it("returns plural for count > 1", () => {
+		expect(inflectFn(2, "apple", "apples")).toBe("apples");
+	});
+	it("returns plural for count 0", () => {
+		expect(inflectFn(0, "apple", "apples")).toBe("apples");
+	});
+	it("includes the count when includeCount is true", () => {
+		expect(inflectFn(2, "apple", "apples", true)).toBe("2 apples");
+	});
+});
+
+describe("ordinalize", () => {
+	const ordinalizeFn = getHelper("ordinalize");
+	it("returns ordinalized strings", () => {
+		expect(ordinalizeFn(1)).toBe("1st");
+		expect(ordinalizeFn(2)).toBe("2nd");
+		expect(ordinalizeFn(3)).toBe("3rd");
+		expect(ordinalizeFn(4)).toBe("4th");
+		expect(ordinalizeFn(11)).toBe("11th");
+		expect(ordinalizeFn(21)).toBe("21st");
+	});
+});


### PR DESCRIPTION
## Summary
- add inflect and ordinalize helpers in TypeScript
- register inflection helpers with the helper registry
- document inflection migration progress and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966f5d8bcc832489c1f6f3791d078b