### PR TITLE
feat: add logging helpers

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -9,6 +9,7 @@ import { helpers as fsHelpers } from "./helpers/fs.js";
 import { helpers as htmlHelpers } from "./helpers/html.js";
 import { helpers as i18nHelpers } from "./helpers/i18n.js";
 import { helpers as inflectionHelpers } from "./helpers/inflection.js";
+import { helpers as loggingHelpers } from "./helpers/logging.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -59,6 +60,8 @@ export class HelperRegistry {
 		this.registerHelpers(i18nHelpers);
 		// Inflection
 		this.registerHelpers(inflectionHelpers);
+		// Logging
+		this.registerHelpers(loggingHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/logging.ts
+++ b/src/helpers/logging.ts
@@ -1,0 +1,64 @@
+import loggingHelpers from "logging-helpers";
+import type { Helper } from "../helper-registry.js";
+
+const {
+	log,
+	ok,
+	success,
+	info,
+	warning,
+	warn,
+	error,
+	danger,
+	bold,
+	_debug,
+	_inspect,
+} = loggingHelpers as Record<string, (...arguments_: unknown[]) => unknown>;
+
+export const helpers: Helper[] = [
+	{ name: "log", category: "logging", fn: log as unknown as Helper["fn"] },
+	{ name: "ok", category: "logging", fn: ok as unknown as Helper["fn"] },
+	{
+		name: "success",
+		category: "logging",
+		fn: success as unknown as Helper["fn"],
+	},
+	{ name: "info", category: "logging", fn: info as unknown as Helper["fn"] },
+	{
+		name: "warning",
+		category: "logging",
+		fn: warning as unknown as Helper["fn"],
+	},
+	{ name: "warn", category: "logging", fn: warn as unknown as Helper["fn"] },
+	{ name: "error", category: "logging", fn: error as unknown as Helper["fn"] },
+	{
+		name: "danger",
+		category: "logging",
+		fn: danger as unknown as Helper["fn"],
+	},
+	{ name: "bold", category: "logging", fn: bold as unknown as Helper["fn"] },
+	{
+		name: "_debug",
+		category: "logging",
+		fn: _debug as unknown as Helper["fn"],
+	},
+	{
+		name: "_inspect",
+		category: "logging",
+		fn: _inspect as unknown as Helper["fn"],
+	},
+];
+
+export {
+	log,
+	ok,
+	success,
+	info,
+	warning,
+	warn,
+	error,
+	danger,
+	bold,
+	_debug,
+	_inspect,
+};

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -33,6 +33,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("inflect")).toBeTruthy();
 	});
+	test("includes logging helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("log")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	_debug,
+	_inspect,
+	bold,
+	danger,
+	error,
+	helpers,
+	info,
+	log,
+	ok,
+	success,
+	warn,
+	warning,
+} from "../src/helpers/logging.js";
+
+describe("logging helpers", () => {
+	test("helpers array exports all logging helpers", () => {
+		const names = helpers.map((h) => h.name).sort();
+		expect(names).toEqual(
+			[
+				"_debug",
+				"_inspect",
+				"bold",
+				"danger",
+				"error",
+				"info",
+				"log",
+				"ok",
+				"success",
+				"warn",
+				"warning",
+			].sort(),
+		);
+	});
+
+	test("log logs to console", () => {
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		log("test");
+		expect(spy).toHaveBeenCalledWith("test");
+		spy.mockRestore();
+	});
+
+	test("ok does not throw", () => {
+		expect(() => ok("ok")).not.toThrow();
+	});
+
+	test("success logs to console", () => {
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		success("yay");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("info logs to console", () => {
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		info("info");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("warning logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		warning("warn");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("warn alias logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		warn("warn");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("error logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		error("err");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("danger alias logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		danger("dang");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("bold logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		bold("bold");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("_debug outputs when value is provided", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		_debug.call({ context: true }, "debug");
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+
+	test("_inspect returns html by default", () => {
+		const result = _inspect({ a: 1 }, { hash: { type: "html" } });
+		expect(result).toContain("<div");
+	});
+});


### PR DESCRIPTION
## Summary
- convert logging helpers to TypeScript and expose all functions
- wire logging helpers into HelperRegistry
- add tests for logging helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689677aa45e083248d5b89cd89660259