### PR TITLE
feat: migrate match helper to TypeScript

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -10,6 +10,7 @@ import { helpers as htmlHelpers } from "./helpers/html.js";
 import { helpers as i18nHelpers } from "./helpers/i18n.js";
 import { helpers as inflectionHelpers } from "./helpers/inflection.js";
 import { helpers as loggingHelpers } from "./helpers/logging.js";
+import { helpers as matchHelpers } from "./helpers/match.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -62,6 +63,8 @@ export class HelperRegistry {
 		this.registerHelpers(inflectionHelpers);
 		// Logging
 		this.registerHelpers(loggingHelpers);
+		// Match
+		this.registerHelpers(matchHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/match.ts
+++ b/src/helpers/match.ts
@@ -1,0 +1,38 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
+import micromatch, { type Options } from "micromatch";
+import type { Helper } from "../helper-registry.js";
+
+const match = (
+	files: string | string[],
+	patterns: string | string[] | RegExp,
+	options?: Options,
+): string[] => {
+	const pats =
+		typeof patterns === "string"
+			? patterns.split(/, */)
+			: (patterns as micromatch.Pattern | micromatch.Pattern[]);
+	return micromatch(files, pats, options) as string[];
+};
+
+const isMatch = (
+	filepath: string,
+	pattern: string | string[] | RegExp,
+	options?: Options,
+): boolean => {
+	return micromatch.isMatch(filepath, pattern as any, options);
+};
+
+const mm = (...args: Parameters<typeof match>): ReturnType<typeof match> => {
+	console.log("the {{mm}} helper is depcrecated and will be removed");
+	console.log("in handlebars-helpers v1.0.0, please use the {{match}}");
+	console.log("helper instead.");
+	return match(...args);
+};
+
+export const helpers: Helper[] = [
+	{ name: "match", category: "match", fn: match as any },
+	{ name: "isMatch", category: "match", fn: isMatch as any },
+	{ name: "mm", category: "match", fn: mm as any },
+];
+
+export { match, isMatch, mm };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -37,6 +37,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("log")).toBeTruthy();
 	});
+	test("includes match helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("match")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/match.test.ts
+++ b/test/helpers/match.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { helpers } from "../../src/helpers/match.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+const matchFn = getHelper("match");
+const isMatchFn = getHelper("isMatch");
+const mmFn = getHelper("mm");
+
+describe("match", () => {
+	it("filters files using a glob pattern string", () => {
+		const files = ["a.js", "b.txt", "c.js"];
+		expect(matchFn(files, "*.js")).toEqual(["a.js", "c.js"]);
+	});
+	it("accepts an array of patterns", () => {
+		const files = ["a.js", "b.txt", "c.md"];
+		expect(matchFn(files, ["*.js", "*.md"]).sort()).toEqual(["a.js", "c.md"]);
+	});
+	it("splits comma separated string patterns", () => {
+		const files = ["a.js", "b.txt", "c.md"];
+		expect(matchFn(files, "*.js, *.md").sort()).toEqual(["a.js", "c.md"]);
+	});
+	it("passes options to micromatch", () => {
+		const files = [".a.js", "b.txt"];
+		expect(matchFn(files, "*", { dot: true })).toEqual([".a.js", "b.txt"]);
+	});
+});
+
+describe("isMatch", () => {
+	it("returns true when pattern matches", () => {
+		expect(isMatchFn("foo.js", "*.js")).toBe(true);
+	});
+	it("returns false when pattern does not match", () => {
+		expect(isMatchFn("foo.js", "*.md")).toBe(false);
+	});
+});
+
+describe("mm", () => {
+	it("logs deprecation warning and delegates to match", () => {
+		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const files = ["a.js", "b.txt"];
+		expect(mmFn(files, "*.js")).toEqual(["a.js"]);
+		expect(spy).toHaveBeenCalledTimes(3);
+		spy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary
- convert match helpers to TypeScript and add deprecation alias
- register match helpers in helper registry
- add thorough tests for match helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689757c9a5e4832482f591be30b27270