### PR TITLE
feat: add typescript math helpers

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -11,6 +11,7 @@ import { helpers as i18nHelpers } from "./helpers/i18n.js";
 import { helpers as inflectionHelpers } from "./helpers/inflection.js";
 import { helpers as loggingHelpers } from "./helpers/logging.js";
 import { helpers as matchHelpers } from "./helpers/match.js";
+import { helpers as mathHelpers } from "./helpers/math.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 
 export enum HelperRegistryCompatibility {
@@ -65,6 +66,8 @@ export class HelperRegistry {
 		this.registerHelpers(loggingHelpers);
 		// Match
 		this.registerHelpers(matchHelpers);
+		// Math
+		this.registerHelpers(mathHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -1,0 +1,141 @@
+import type { Helper } from "../helper-registry.js";
+
+const isNumeric = (value: unknown): value is number | string =>
+	(typeof value === "number" && !Number.isNaN(value)) ||
+	(typeof value === "string" &&
+		value.trim() !== "" &&
+		!Number.isNaN(Number(value)));
+
+const toNumber = (value: unknown, message = "expected a number"): number => {
+	if (isNumeric(value)) {
+		return Number(value);
+	}
+	throw new TypeError(message);
+};
+
+const abs = (value: unknown): number => {
+	const num = toNumber(value);
+	return Math.abs(num);
+};
+
+const add = (a: unknown, b: unknown): number | "" => {
+	if (isNumeric(a) && isNumeric(b)) {
+		return Number(a) + Number(b);
+	}
+	return "";
+};
+
+const avg = (...values: Array<number | number[]>): number => {
+	const flat: number[] = values.flat().map((n) => Number(n));
+	return sum(flat) / flat.length;
+};
+
+const ceil = (value: unknown): number => {
+	const num = toNumber(value);
+	return Math.ceil(num);
+};
+
+const divide = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA / numB;
+};
+
+const floor = (value: unknown): number => {
+	const num = toNumber(value);
+	return Math.floor(num);
+};
+
+const minus = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA - numB;
+};
+
+const modulo = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA % numB;
+};
+
+const multiply = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA * numB;
+};
+
+const plus = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA + numB;
+};
+
+const random = (min: unknown, max: unknown): number => {
+	const minNum = toNumber(min, "expected minimum to be a number");
+	const maxNum = toNumber(max, "expected maximum to be a number");
+	return minNum + Math.floor(Math.random() * (maxNum - minNum + 1));
+};
+
+const remainder = (a: number, b: number): number => a % b;
+
+const round = (value: unknown): number => {
+	const num = toNumber(value);
+	return Math.round(num);
+};
+
+const subtract = (a: unknown, b: unknown): number => {
+	const numA = toNumber(a, "expected the first argument to be a number");
+	const numB = toNumber(b, "expected the second argument to be a number");
+	return numA - numB;
+};
+
+const sum = (...values: Array<number | number[]>): number => {
+	const flat = values.flat();
+	let total = 0;
+	for (const value of flat) {
+		if (isNumeric(value)) {
+			total += Number(value);
+		}
+	}
+	return total;
+};
+
+const times = (a: unknown, b: unknown): number => multiply(a, b);
+
+export const helpers: Helper[] = [
+	{ name: "abs", category: "math", fn: abs },
+	{ name: "add", category: "math", fn: add },
+	{ name: "avg", category: "math", fn: avg },
+	{ name: "ceil", category: "math", fn: ceil },
+	{ name: "divide", category: "math", fn: divide },
+	{ name: "floor", category: "math", fn: floor },
+	{ name: "minus", category: "math", fn: minus },
+	{ name: "modulo", category: "math", fn: modulo },
+	{ name: "multiply", category: "math", fn: multiply },
+	{ name: "plus", category: "math", fn: plus },
+	{ name: "random", category: "math", fn: random },
+	{ name: "remainder", category: "math", fn: remainder },
+	{ name: "round", category: "math", fn: round },
+	{ name: "subtract", category: "math", fn: subtract },
+	{ name: "sum", category: "math", fn: sum },
+	{ name: "times", category: "math", fn: times },
+];
+
+export {
+	abs,
+	add,
+	avg,
+	ceil,
+	divide,
+	floor,
+	minus,
+	modulo,
+	multiply,
+	plus,
+	random,
+	remainder,
+	round,
+	subtract,
+	sum,
+	times,
+};

--- a/test/helpers/math.test.ts
+++ b/test/helpers/math.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { helpers } from "../../src/helpers/math.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("abs", () => {
+	const fn = getHelper("abs");
+	it("returns magnitude", () => {
+		expect(fn(-5)).toBe(5);
+	});
+	it("throws on non-number", () => {
+		expect(() => fn("a")).toThrow(/expected a number/);
+	});
+});
+
+describe("add", () => {
+	const fn = getHelper("add");
+	it("adds numeric values", () => {
+		expect(fn(5, 5)).toBe(10);
+		expect(fn("5", "5")).toBe(10);
+	});
+	it("returns empty string when invalid", () => {
+		expect(fn("a", 2)).toBe("");
+	});
+});
+
+describe("avg", () => {
+	const fn = getHelper("avg");
+	it("averages numbers", () => {
+		expect(fn(1, 2, 3, 4)).toBe(2.5);
+	});
+	it("averages arrays", () => {
+		expect(fn([1, 3, 6, 9])).toBe(4.75);
+	});
+});
+
+describe("ceil", () => {
+	const fn = getHelper("ceil");
+	it("rounds up", () => {
+		expect(fn(5.1)).toBe(6);
+	});
+	it("throws on non-number", () => {
+		expect(() => fn("a")).toThrow();
+	});
+});
+
+describe("divide", () => {
+	const fn = getHelper("divide");
+	it("divides numbers", () => {
+		expect(fn(10, 2)).toBe(5);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("floor", () => {
+	const fn = getHelper("floor");
+	it("rounds down", () => {
+		expect(fn(5.9)).toBe(5);
+	});
+	it("throws on non-number", () => {
+		expect(() => fn("a")).toThrow();
+	});
+});
+
+describe("minus", () => {
+	const fn = getHelper("minus");
+	it("subtracts numbers", () => {
+		expect(fn(10, 3)).toBe(7);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("modulo", () => {
+	const fn = getHelper("modulo");
+	it("returns modulo", () => {
+		expect(fn(10, 3)).toBe(1);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("multiply", () => {
+	const fn = getHelper("multiply");
+	it("multiplies numbers", () => {
+		expect(fn(5, 5)).toBe(25);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("plus", () => {
+	const fn = getHelper("plus");
+	it("adds numbers", () => {
+		expect(fn(5, 5)).toBe(10);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("random", () => {
+	const fn = getHelper("random");
+	it("returns value in range", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		expect(fn(1, 3)).toBe(2);
+		vi.restoreAllMocks();
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(1, "b")).toThrow();
+	});
+});
+
+describe("remainder", () => {
+	const fn = getHelper("remainder");
+	it("returns remainder", () => {
+		expect(fn(7, 5)).toBe(2);
+	});
+});
+
+describe("round", () => {
+	const fn = getHelper("round");
+	it("rounds", () => {
+		expect(fn(5.5)).toBe(6);
+	});
+	it("throws on non-number", () => {
+		expect(() => fn("a")).toThrow();
+	});
+});
+
+describe("subtract", () => {
+	const fn = getHelper("subtract");
+	it("subtracts numbers", () => {
+		expect(fn(5, 3)).toBe(2);
+	});
+	it("throws on invalid arguments", () => {
+		expect(() => fn("a", 2)).toThrow();
+		expect(() => fn(2, "b")).toThrow();
+	});
+});
+
+describe("sum", () => {
+	const fn = getHelper("sum");
+	it("sums numbers", () => {
+		expect(fn(1, 2, 3)).toBe(6);
+	});
+	it("sums arrays", () => {
+		expect(fn([1, 2, 3], 4)).toBe(10);
+	});
+	it("ignores non-numeric", () => {
+		expect(fn([1, "a", 2])).toBe(3);
+	});
+});
+
+describe("times", () => {
+	const fn = getHelper("times");
+	it("multiplies numbers", () => {
+		expect(fn(3, 4)).toBe(12);
+	});
+});


### PR DESCRIPTION
## Summary
- add math helper implementations in TypeScript
- test math helpers with full coverage
- register math helpers in helper registry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975f07b264832480e943bf5c024587