### PR TITLE
Add TypeScript misc helpers and register in helper registry

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -13,6 +13,7 @@ import { helpers as loggingHelpers } from "./helpers/logging.js";
 import { helpers as matchHelpers } from "./helpers/match.js";
 import { helpers as mathHelpers } from "./helpers/math.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
+import { helpers as miscHelpers } from "./helpers/misc.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -68,6 +69,8 @@ export class HelperRegistry {
 		this.registerHelpers(matchHelpers);
 		// Math
 		this.registerHelpers(mathHelpers);
+		// Misc
+		this.registerHelpers(miscHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,0 +1,43 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: handlebars helpers use any for context
+
+import get from "get-value";
+import createFrame from "handlebars-helper-create-frame";
+import util from "handlebars-utils";
+import kindOf from "kind-of";
+import type { Helper } from "../helper-registry.js";
+
+const frame = createFrame as (this: any, ...args: any[]) => any;
+
+function option(this: any, prop: string, locals?: any, options?: any): any {
+	return get(util.options(this, locals, options), prop);
+}
+
+function noop(this: any, options: { fn: (context: any) => any }): any {
+	return options.fn(this);
+}
+
+const typeOf = kindOf as (value: any) => string;
+
+function withHash(
+	this: any,
+	options: {
+		hash?: Record<string, any>;
+		fn: (hash: Record<string, any>) => any;
+		inverse: (context: any) => any;
+	},
+): any {
+	if (options.hash && Object.keys(options.hash).length) {
+		return options.fn(options.hash);
+	}
+	return options.inverse(this);
+}
+
+export const helpers: Helper[] = [
+	{ name: "frame", category: "misc", fn: frame as any },
+	{ name: "option", category: "misc", fn: option },
+	{ name: "noop", category: "misc", fn: noop },
+	{ name: "typeOf", category: "misc", fn: typeOf as any },
+	{ name: "withHash", category: "misc", fn: withHash },
+];
+
+export { frame, option, noop, typeOf, withHash };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -41,6 +41,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("match")).toBeTruthy();
 	});
+	test("includes misc helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("noop")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/misc.test.ts
+++ b/test/helpers/misc.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/misc.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("misc helpers", () => {
+	it("should include frame helper", () => {
+		const frameFn = getHelper("frame");
+		expect(typeof frameFn).toBe("function");
+	});
+
+	it("option retrieves nested property", () => {
+		const optionFn = getHelper("option");
+		const context = { options: { a: { b: { c: "ddd" } } } };
+		const result = optionFn.call(context, "a.b.c");
+		expect(result).toBe("ddd");
+	});
+
+	it("noop returns block content", () => {
+		const noopFn = getHelper("noop");
+		const context = { value: "content" };
+		const result = noopFn.call(context, {
+			fn: (ctx: { value: string }) => ctx.value,
+		});
+		expect(result).toBe("content");
+	});
+
+	it("typeOf returns native type", () => {
+		const typeOfFn = getHelper("typeOf");
+		expect(typeOfFn(1)).toBe("number");
+		expect(typeOfFn("1")).toBe("string");
+	});
+
+	it("withHash uses hash when provided", () => {
+		const withHashFn = getHelper("withHash");
+		const result = withHashFn.call(
+			{},
+			{
+				hash: { a: 1 },
+				fn: (hash: { a: number }) => hash.a,
+				inverse: () => "no",
+			},
+		);
+		expect(result).toBe(1);
+	});
+
+	it("withHash falls back to inverse when hash empty", () => {
+		const withHashFn = getHelper("withHash");
+		const context = { value: "inv" };
+		const result = withHashFn.call(context, {
+			hash: {},
+			fn: () => "yes",
+			inverse: (ctx: { value: string }) => ctx.value,
+		});
+		expect(result).toBe("inv");
+	});
+});


### PR DESCRIPTION
## Summary
- convert legacy misc helpers to TypeScript and expose frame, option, noop, typeOf, and withHash
- register misc helpers with the HelperRegistry
- add tests for misc helpers and registry inclusion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689762b8431083248d52bc47339195bb