### PR TITLE
feat: add number helpers in TypeScript

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -14,6 +14,7 @@ import { helpers as matchHelpers } from "./helpers/match.js";
 import { helpers as mathHelpers } from "./helpers/math.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 import { helpers as miscHelpers } from "./helpers/misc.js";
+import { helpers as numberHelpers } from "./helpers/number.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -71,6 +72,8 @@ export class HelperRegistry {
 		this.registerHelpers(mathHelpers);
 		// Misc
 		this.registerHelpers(miscHelpers);
+		// Number
+		this.registerHelpers(numberHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -1,0 +1,108 @@
+import type { Helper } from "../helper-registry.js";
+
+const isNumeric = (value: unknown): value is number =>
+	typeof value === "number" && !Number.isNaN(value);
+
+const bytes = (value: unknown, precision?: unknown): string => {
+	if (value == null) return "0 B";
+
+	let num: number;
+	if (typeof value === "string") {
+		num = value.length;
+		if (!num) return "0 B";
+	} else if (isNumeric(value)) {
+		num = Number(value);
+	} else if (typeof (value as { length?: number }).length === "number") {
+		num = (value as { length: number }).length;
+		if (!num) return "0 B";
+	} else {
+		return "0 B";
+	}
+
+	const prec =
+		typeof precision === "number" && !Number.isNaN(precision) ? precision : 2;
+	const abbr = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+	const factor = 10 ** prec;
+
+	for (let i = abbr.length - 1; i >= 0; i--) {
+		const size = 10 ** (i * 3);
+		if (size <= num + 1) {
+			const val = Math.round((num * factor) / size) / factor;
+			return `${val} ${abbr[i]}`;
+		}
+	}
+
+	return `${num}`;
+};
+
+const addCommas = (num: number | string): string =>
+	num.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");
+
+const phoneNumber = (num: number | string): string => {
+	const str = num.toString();
+	return `(${str.substr(0, 3)}) ${str.substr(3, 3)}-${str.substr(6, 4)}`;
+};
+
+const toAbbr = (value: unknown, precision?: unknown): string => {
+	const num = isNumeric(value) ? Number(value) : 0;
+	const prec =
+		typeof precision === "number" && !Number.isNaN(precision) ? precision : 2;
+	const factor = 10 ** prec;
+	const abbr = ["k", "m", "b", "t", "q"];
+
+	for (let i = abbr.length - 1; i >= 0; i--) {
+		const size = 10 ** ((i + 1) * 3);
+		if (size <= num + 1) {
+			const val = Math.round((num * factor) / size) / factor;
+			return `${val}${abbr[i]}`;
+		}
+	}
+	return `${num}`;
+};
+
+const toExponential = (value: unknown, digits?: unknown): string => {
+	const num = isNumeric(value) ? Number(value) : 0;
+	const d = typeof digits === "number" && !Number.isNaN(digits) ? digits : 0;
+	return Number(num).toExponential(d);
+};
+
+const toFixed = (value: unknown, digits?: unknown): string => {
+	const num = isNumeric(value) ? Number(value) : 0;
+	const d = typeof digits === "number" && !Number.isNaN(digits) ? digits : 0;
+	return Number(num).toFixed(d);
+};
+
+const toFloat = (value: unknown): number => parseFloat(String(value));
+
+const toInt = (value: unknown): number => parseInt(String(value), 10);
+
+const toPrecision = (value: unknown, precision?: unknown): string => {
+	const num = isNumeric(value) ? Number(value) : 0;
+	const prec =
+		typeof precision === "number" && !Number.isNaN(precision) ? precision : 1;
+	return Number(num).toPrecision(prec);
+};
+
+export const helpers: Helper[] = [
+	{ name: "bytes", category: "number", fn: bytes },
+	{ name: "addCommas", category: "number", fn: addCommas },
+	{ name: "phoneNumber", category: "number", fn: phoneNumber },
+	{ name: "toAbbr", category: "number", fn: toAbbr },
+	{ name: "toExponential", category: "number", fn: toExponential },
+	{ name: "toFixed", category: "number", fn: toFixed },
+	{ name: "toFloat", category: "number", fn: toFloat },
+	{ name: "toInt", category: "number", fn: toInt },
+	{ name: "toPrecision", category: "number", fn: toPrecision },
+];
+
+export {
+	bytes,
+	addCommas,
+	phoneNumber,
+	toAbbr,
+	toExponential,
+	toFixed,
+	toFloat,
+	toInt,
+	toPrecision,
+};

--- a/test/helpers/number.test.ts
+++ b/test/helpers/number.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/number.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("bytes", () => {
+	const fn = getHelper("bytes");
+	it("formats numbers", () => {
+		expect(fn(13661855)).toBe("13.66 MB");
+		expect(fn(825399)).toBe("825.4 kB");
+		expect(fn(1396)).toBe("1.4 kB");
+		expect(fn(0)).toBe("0 B");
+		expect(fn(1)).toBe("1 B");
+		expect(fn(2)).toBe("2 B");
+	});
+	it("uses precision", () => {
+		expect(fn(1024, 0)).toBe("1 kB");
+	});
+	it("handles invalid values", () => {
+		expect(fn({} as unknown as number)).toBe("0 B");
+		expect(fn(undefined)).toBe("0 B");
+	});
+	it("uses string length", () => {
+		expect(fn("foo")).toBe("3 B");
+		expect(fn("foobar")).toBe("6 B");
+		expect(fn("")).toBe("0 B");
+	});
+	it("uses object length", () => {
+		expect(fn({ length: 5 })).toBe("5 B");
+		expect(fn({ length: 0 })).toBe("0 B");
+	});
+	it("returns negative numbers", () => {
+		expect(fn(-1)).toBe("-1");
+	});
+});
+
+describe("phoneNumber", () => {
+	const fn = getHelper("phoneNumber");
+	it("formats phone numbers", () => {
+		expect(fn("8005551212")).toBe("(800) 555-1212");
+	});
+});
+
+describe("toFixed", () => {
+	const fn = getHelper("toFixed");
+	it("rounds", () => {
+		expect(fn(5.53231)).toBe("6");
+	});
+	it("rounds with digits", () => {
+		expect(fn(5.53231, 3)).toBe("5.532");
+	});
+	it("defaults when invalid", () => {
+		expect(fn(undefined)).toBe("0");
+	});
+});
+
+describe("toPrecision", () => {
+	const fn = getHelper("toPrecision");
+	it("returns exponential", () => {
+		expect(fn(555.322)).toBe("6e+2");
+	});
+	it("returns fixed digits", () => {
+		expect(fn(555.322, 4)).toBe("555.3");
+	});
+	it("handles invalid", () => {
+		expect(fn(undefined)).toBe("0");
+	});
+});
+
+describe("toExponential", () => {
+	const fn = getHelper("toExponential");
+	it("formats", () => {
+		expect(fn(5)).toBe("5e+0");
+	});
+	it("formats with digits", () => {
+		expect(fn(5, 5)).toBe("5.00000e+0");
+	});
+	it("handles invalid", () => {
+		expect(fn(undefined)).toBe("0e+0");
+	});
+});
+
+describe("toInt", () => {
+	const fn = getHelper("toInt");
+	it("parses int", () => {
+		expect(fn("3cc")).toBe(3);
+	});
+});
+
+describe("toFloat", () => {
+	const fn = getHelper("toFloat");
+	it("parses float", () => {
+		expect(fn("3.1cc")).toBe(3.1);
+	});
+});
+
+describe("addCommas", () => {
+	const fn = getHelper("addCommas");
+	it("adds commas", () => {
+		expect(fn(2222222)).toBe("2,222,222");
+	});
+});
+
+describe("toAbbr", () => {
+	const fn = getHelper("toAbbr");
+	it("abbreviates numbers", () => {
+		expect(fn(123456789)).toBe("123.46m");
+	});
+	it("abbreviates with precision", () => {
+		expect(fn(123456789, 3)).toBe("123.457m");
+	});
+	it("rounds up", () => {
+		expect(fn(999)).toBe("1k");
+	});
+	it("handles big numbers", () => {
+		expect(fn(9999999, 0)).toBe("10m");
+		expect(fn(1000000000)).toBe("1b");
+		expect(fn(1000000000000)).toBe("1t");
+		expect(fn(1000000000000000)).toBe("1q");
+		expect(fn(99393999393)).toBe("99.39b");
+	});
+	it("defaults when invalid", () => {
+		expect(fn(undefined)).toBe("0");
+	});
+});


### PR DESCRIPTION
## Summary
- convert number helper utilities to TypeScript
- register number helpers with helper registry
- cover numeric formatting features with tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897668b12a08324ae71ec6807dae687