### PR TITLE
feat: add object helpers

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -15,6 +15,7 @@ import { helpers as mathHelpers } from "./helpers/math.js";
 import { helpers as mdHelpers } from "./helpers/md.js";
 import { helpers as miscHelpers } from "./helpers/misc.js";
 import { helpers as numberHelpers } from "./helpers/number.js";
+import { helpers as objectHelpers } from "./helpers/object.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -74,6 +75,8 @@ export class HelperRegistry {
 		this.registerHelpers(miscHelpers);
 		// Number
 		this.registerHelpers(numberHelpers);
+		// Object
+		this.registerHelpers(objectHelpers);
 	}
 
 	public register(helper: Helper): boolean {

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -1,0 +1,150 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: handlebars helpers use any for context
+
+import getObject from "get-object";
+import get from "get-value";
+import type { Helper } from "../helper-registry.js";
+import { arrayify } from "./array.js";
+
+const isOptions = (value: any): value is { hash: Record<string, any> } => {
+	return Boolean(value && typeof value === "object" && "hash" in value);
+};
+
+const createFrame = (options: any, hash: any) => ({
+	...(options?.data || {}),
+	...hash,
+});
+
+const extend = (...objects: any[]): Record<string, any> => {
+	const args = [...objects];
+	if (args.length && isOptions(args[args.length - 1])) {
+		const opts = args.pop() as { hash: Record<string, any> };
+		args.push(opts.hash);
+	}
+	const result: Record<string, any> = {};
+	for (const obj of args) {
+		if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+			Object.assign(result, obj);
+		}
+	}
+	return result;
+};
+const forIn = (obj: any, options: any): string => {
+	if (!isOptions(options)) {
+		return options?.inverse?.(obj) ?? "";
+	}
+	const data = createFrame(options, options.hash || {});
+	let result = "";
+	for (const key in obj) {
+		data.key = key;
+		result += options.fn(obj[key], { data });
+	}
+	return result;
+};
+const forOwn = (obj: any, options: any): string => {
+	if (!isOptions(options)) {
+		return options?.inverse?.(obj) ?? "";
+	}
+	const data = createFrame(options, options.hash || {});
+	let result = "";
+	for (const key in obj) {
+		if (Object.hasOwn(obj, key)) {
+			data.key = key;
+			result += options.fn(obj[key], { data });
+		}
+	}
+	return result;
+};
+
+const toPath = (...prop: Array<string | number>): string => {
+	const parts: Array<string | number> = [];
+	for (const p of prop) {
+		if (typeof p === "string" || typeof p === "number") {
+			parts.push(p);
+		}
+	}
+	return parts.join(".");
+};
+const getHelper = (prop: string, context: any, options?: any): any => {
+	const val = get(context, prop);
+	if (options && typeof options.fn === "function") {
+		return val ? options.fn(val) : options.inverse?.(context);
+	}
+	return val;
+};
+const getObjectHelper = (prop: string, context: any): any => {
+	return getObject(context, prop);
+};
+const hasOwn = (context: any, key: string): boolean => {
+	return Object.hasOwn(context, key);
+};
+
+const isObject = (value: unknown): boolean => {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+};
+
+const JSONparse = (str: string): any => {
+	return JSON.parse(str);
+};
+const JSONstringify = (obj: any, indent?: number): string => {
+	const ind = typeof indent === "number" ? indent : 0;
+	return JSON.stringify(obj, null, ind);
+};
+const merge = (context: any, ...objects: any[]): Record<string, any> => {
+	const args = [context, ...objects];
+	if (args.length && isOptions(args[args.length - 1])) {
+		const opts = args.pop() as { hash: Record<string, any> };
+		args.push(opts.hash);
+	}
+	return Object.assign(...args);
+};
+
+const parseJSON = JSONparse;
+const stringify = JSONstringify;
+const pick = (props: string | string[], context: any, options?: any): any => {
+	const keys = arrayify(props);
+	let result: Record<string, any> = {};
+	for (const key of keys) {
+		result = Object.assign({}, result, getObject(context, key));
+	}
+	if (options && typeof options.fn === "function") {
+		if (Object.keys(result).length) {
+			return options.fn(result);
+		}
+		return options.inverse?.(context);
+	}
+	return result;
+};
+
+export const helpers: Helper[] = [
+	{ name: "extend", category: "object", fn: extend },
+	{ name: "forIn", category: "object", fn: forIn as any },
+	{ name: "forOwn", category: "object", fn: forOwn as any },
+	{ name: "toPath", category: "object", fn: toPath as any },
+	{ name: "get", category: "object", fn: getHelper as any },
+	{ name: "getObject", category: "object", fn: getObjectHelper as any },
+	{ name: "hasOwn", category: "object", fn: hasOwn as any },
+	{ name: "isObject", category: "object", fn: isObject as any },
+	{ name: "JSONparse", category: "object", fn: JSONparse as any },
+	{ name: "JSONstringify", category: "object", fn: JSONstringify as any },
+	{ name: "merge", category: "object", fn: merge as any },
+	{ name: "parseJSON", category: "object", fn: parseJSON as any },
+	{ name: "pick", category: "object", fn: pick as any },
+	{ name: "stringify", category: "object", fn: stringify as any },
+];
+
+export {
+	extend,
+	forIn,
+	forOwn,
+	toPath,
+	getHelper as get,
+	getObjectHelper as getObject,
+	hasOwn,
+	isObject,
+	JSONparse,
+	JSONstringify,
+	merge,
+	parseJSON,
+	pick,
+	stringify,
+};

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -45,6 +45,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("noop")).toBeTruthy();
 	});
+	test("includes object helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("extend")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {

--- a/test/helpers/object.test.ts
+++ b/test/helpers/object.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/object.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("extend", () => {
+	const extendFn = getHelper("extend");
+	it("merges objects", () => {
+		expect(extendFn({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+	});
+	it("handles options hash", () => {
+		expect(extendFn({ a: 1 }, { b: 2 }, { hash: { c: 3 } })).toEqual({
+			a: 1,
+			b: 2,
+			c: 3,
+		});
+	});
+	it("ignores non-objects", () => {
+		expect(extendFn({ a: 1 }, "nope", { hash: { b: 2 } })).toEqual({
+			a: 1,
+			b: 2,
+		});
+	});
+});
+
+describe("forIn", () => {
+	const forInFn = getHelper("forIn");
+	it("iterates all enumerable properties", () => {
+		const proto = { p: 1 };
+		const obj = Object.create(proto);
+		obj.a = 2;
+		const calls: string[] = [];
+		const res = forInFn(obj, {
+			hash: {},
+			fn: (val: unknown, { data }: { data: { key: string } }) => {
+				calls.push(`${data.key}:${String(val)}`);
+				return "";
+			},
+			inverse: () => "inv",
+		});
+		expect(res).toBe("");
+		expect(calls).toContain("a:2");
+		expect(calls).toContain("p:1");
+	});
+	it("handles undefined hash", () => {
+		const obj = { a: 1 };
+		const calls: string[] = [];
+		forInFn(obj, {
+			hash: undefined,
+			fn: (val: unknown, { data }: { data: { key: string } }) => {
+				calls.push(`${data.key}:${String(val)}`);
+				return "";
+			},
+			inverse: () => "inv",
+		} as unknown as {
+			hash: undefined;
+			fn: (val: unknown, ctx: { data: { key: string } }) => string;
+			inverse: () => string;
+		});
+		expect(calls).toEqual(["a:1"]);
+	});
+	it("uses inverse when options invalid", () => {
+		const res = forInFn({ a: 1 }, { inverse: () => "nope" } as unknown as {
+			inverse: () => string;
+		});
+		expect(res).toBe("nope");
+	});
+	it("returns empty string when inverse missing", () => {
+		const res = forInFn({ a: 1 }, {} as unknown as Record<string, unknown>);
+		expect(res).toBe("");
+	});
+});
+
+describe("forOwn", () => {
+	const forOwnFn = getHelper("forOwn");
+	it("iterates own properties only", () => {
+		const proto = { p: 1 };
+		const obj = Object.create(proto);
+		obj.a = 2;
+		const calls: string[] = [];
+		forOwnFn(obj, {
+			hash: {},
+			fn: (val: unknown, { data }: { data: { key: string } }) => {
+				calls.push(`${data.key}:${String(val)}`);
+				return "";
+			},
+			inverse: () => "inv",
+		});
+		expect(calls).toEqual(["a:2"]);
+	});
+	it("handles undefined hash", () => {
+		const obj = { a: 1 };
+		const calls: string[] = [];
+		forOwnFn(obj, {
+			hash: undefined,
+			fn: (val: unknown, { data }: { data: { key: string } }) => {
+				calls.push(`${data.key}:${String(val)}`);
+				return "";
+			},
+			inverse: () => "inv",
+		} as unknown as {
+			hash: undefined;
+			fn: (val: unknown, ctx: { data: { key: string } }) => string;
+			inverse: () => string;
+		});
+		expect(calls).toEqual(["a:1"]);
+	});
+	it("uses inverse when options invalid", () => {
+		const res = forOwnFn({ a: 1 }, { inverse: () => "none" } as unknown as {
+			inverse: () => string;
+		});
+		expect(res).toBe("none");
+	});
+	it("returns empty string when inverse missing", () => {
+		const res = forOwnFn({ a: 1 }, {} as unknown as Record<string, unknown>);
+		expect(res).toBe("");
+	});
+});
+
+describe("toPath", () => {
+	const toPathFn = getHelper("toPath");
+	it("joins path segments", () => {
+		expect(toPathFn("a", "b", 1)).toBe("a.b.1");
+	});
+	it("ignores non-string segments", () => {
+		expect(toPathFn("a", { foo: 1 }, 2)).toBe("a.2");
+	});
+});
+
+describe("get", () => {
+	const getFn = getHelper("get");
+	const context = { a: { b: 2 } };
+	it("retrieves value", () => {
+		expect(getFn("a.b", context)).toBe(2);
+	});
+	it("uses block helper when value exists", () => {
+		const res = getFn("a.b", context, {
+			fn: (v: number) => v * 2,
+			inverse: () => "none",
+		});
+		expect(res).toBe(4);
+	});
+	it("uses inverse when value missing", () => {
+		const res = getFn("a.c", context, {
+			fn: (v: unknown) => v,
+			inverse: () => "missing",
+		});
+		expect(res).toBe("missing");
+	});
+});
+
+describe("getObject", () => {
+	const getObjectFn = getHelper("getObject");
+	it("returns object at path", () => {
+		expect(getObjectFn("a.b", { a: { b: 2 } })).toEqual({ b: 2 });
+	});
+});
+
+describe("hasOwn", () => {
+	const hasOwnFn = getHelper("hasOwn");
+	it("checks own property", () => {
+		const obj = Object.create({ a: 1 });
+		obj.b = 2;
+		expect(hasOwnFn(obj, "b")).toBe(true);
+		expect(hasOwnFn(obj, "a")).toBe(false);
+	});
+});
+
+describe("isObject", () => {
+	const isObjectFn = getHelper("isObject");
+	it("detects objects", () => {
+		expect(isObjectFn({})).toBe(true);
+		expect(isObjectFn([])).toBe(false);
+	});
+});
+
+describe("JSONparse", () => {
+	const parseFn = getHelper("JSONparse");
+	it("parses JSON", () => {
+		expect(parseFn('{"a":1}')).toEqual({ a: 1 });
+	});
+});
+
+describe("JSONstringify", () => {
+	const stringifyFn = getHelper("JSONstringify");
+	it("stringifies without indent", () => {
+		expect(stringifyFn({ a: 1 })).toBe('{"a":1}');
+	});
+	it("stringifies with indent", () => {
+		expect(stringifyFn({ a: 1 }, 2)).toBe(`{
+  "a": 1
+}`);
+	});
+});
+
+describe("merge", () => {
+	const mergeFn = getHelper("merge");
+	it("merges objects and options hash", () => {
+		const target = { a: 1 };
+		const res = mergeFn(target, { b: 2 }, { hash: { c: 3 } });
+		expect(res).toEqual({ a: 1, b: 2, c: 3 });
+		expect(target).toEqual({ a: 1, b: 2, c: 3 });
+	});
+	it("merges without options", () => {
+		const target = { a: 1 };
+		mergeFn(target, { b: 2 });
+		expect(target).toEqual({ a: 1, b: 2 });
+	});
+});
+
+describe("parseJSON alias", () => {
+	const parseJSONFn = getHelper("parseJSON");
+	it("works like JSONparse", () => {
+		expect(parseJSONFn('{"a":1}')).toEqual({ a: 1 });
+	});
+});
+
+describe("pick", () => {
+	const pickFn = getHelper("pick");
+	const ctx = { a: 1, b: 2, c: 3 };
+	it("picks properties", () => {
+		expect(pickFn(["a", "c"], ctx)).toEqual({ a: 1, c: 3 });
+	});
+	it("block helper with found props", () => {
+		const res = pickFn("a", ctx, {
+			fn: (v: Record<string, number>) => v.a,
+			inverse: () => "none",
+		});
+		expect(res).toBe(1);
+	});
+	it("block helper with missing props", () => {
+		const res = pickFn("d", ctx, {
+			fn: (v: Record<string, unknown>) => (v as { d?: unknown }).d,
+			inverse: () => "missing",
+		});
+		expect(res).toBe("missing");
+	});
+});
+
+describe("stringify alias", () => {
+	const stringifyAlias = getHelper("stringify");
+	it("works like JSONstringify", () => {
+		expect(stringifyAlias({ a: 1 })).toBe('{"a":1}');
+	});
+});


### PR DESCRIPTION
## Summary
- add TypeScript implementation for object helpers
- test object helpers and register in helper registry

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689770271adc8324b34a1b2ed994591c