### PR TITLE
feat: add path helper

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -16,6 +16,7 @@ import { helpers as mdHelpers } from "./helpers/md.js";
 import { helpers as miscHelpers } from "./helpers/misc.js";
 import { helpers as numberHelpers } from "./helpers/number.js";
 import { helpers as objectHelpers } from "./helpers/object.js";
+import { helpers as pathHelpers } from "./helpers/path.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -75,6 +76,8 @@ export class HelperRegistry {
 		this.registerHelpers(miscHelpers);
 		// Number
 		this.registerHelpers(numberHelpers);
+		// Path
+		this.registerHelpers(pathHelpers);
 		// Object
 		this.registerHelpers(objectHelpers);
 	}

--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -1,0 +1,113 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
+import path from "node:path";
+import type { Helper } from "../helper-registry.js";
+
+const expectedType = (
+	variableName: string,
+	expectedType: string,
+	variableValue: unknown,
+): string => {
+	const actualType = Object.prototype.toString
+		.call(variableValue)
+		.slice(8, -1)
+		.toLowerCase();
+	return `Expected ${variableName} to be of type ${expectedType}, but got ${actualType}`;
+};
+
+const assertString = (name: string, value: unknown): string => {
+	if (typeof value !== "string") {
+		throw new TypeError(expectedType(name, "string", value));
+	}
+	return value;
+};
+
+type Options = { data?: { root?: { cwd?: string } } };
+
+const absolute = function (
+	this: { cwd?: string } | undefined,
+	filepath: unknown,
+	options?: Options,
+): string {
+	const fp = assertString("filepath", filepath);
+	const cwd = options?.data?.root?.cwd ?? this?.cwd ?? process.cwd();
+	return path.resolve(cwd, fp);
+};
+
+const dirname = (filepath: unknown): string => {
+	const fp = assertString("filepath", filepath);
+	return path.dirname(fp);
+};
+
+const relative = (a: unknown, b: unknown): string => {
+	const from = assertString("first path", a);
+	const to = assertString("second path", b);
+	return path.relative(path.dirname(from), to);
+};
+
+const basename = (filepath: unknown): string => {
+	const fp = assertString("filepath", filepath);
+	return path.basename(fp);
+};
+
+const stem = (filepath: unknown): string => {
+	const fp = assertString("filepath", filepath);
+	return path.basename(fp, path.extname(fp));
+};
+
+const extname = (filepath: unknown): string => {
+	const fp = assertString("filepath", filepath);
+	return path.extname(fp);
+};
+
+const resolveFn = function (
+	this: { cwd?: string } | undefined,
+	filepath: unknown,
+	...paths: unknown[]
+): string {
+	let options: Options | undefined;
+	const last = paths[paths.length - 1];
+	if (
+		typeof last === "object" &&
+		last &&
+		"data" in (last as Record<string, unknown>)
+	) {
+		options = paths.pop() as Options;
+	}
+	const cwd = options?.data?.root?.cwd ?? this?.cwd ?? process.cwd();
+	const all = [
+		cwd,
+		assertString("filepath", filepath),
+		...paths.map((p, i) => assertString(`path${i}`, p)),
+	];
+	return path.resolve(...all);
+};
+
+const segments = (filepath: unknown, a: unknown, b: unknown): string => {
+	const fp = assertString("filepath", filepath);
+	const start = Number(a);
+	const end = Number(b);
+	const segmentsArr = fp.split(/[\\/]+/);
+	return segmentsArr.slice(start, end).join("/");
+};
+
+export const helpers: Helper[] = [
+	{ name: "absolute", category: "path", fn: absolute as any },
+	{ name: "dirname", category: "path", fn: dirname as any },
+	{ name: "relative", category: "path", fn: relative as any },
+	{ name: "basename", category: "path", fn: basename as any },
+	{ name: "stem", category: "path", fn: stem as any },
+	{ name: "extname", category: "path", fn: extname as any },
+	{ name: "resolve", category: "path", fn: resolveFn as any },
+	{ name: "segments", category: "path", fn: segments as any },
+];
+
+export {
+	absolute,
+	dirname,
+	relative,
+	basename,
+	stem,
+	extname,
+	resolveFn as resolve,
+	segments,
+};

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -45,6 +45,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("noop")).toBeTruthy();
 	});
+	test("includes path helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("basename")).toBeTruthy();
+	});
 	test("includes object helpers by default", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("extend")).toBeTruthy();

--- a/test/helpers/path.test.ts
+++ b/test/helpers/path.test.ts
@@ -1,0 +1,143 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/path.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("absolute", () => {
+	const fn = getHelper("absolute");
+	it("creates absolute paths", () => {
+		expect(fn("a/b/c/package.json")).toBe(path.resolve("a/b/c/package.json"));
+		expect(fn("a/b/c/docs/toc.md")).toBe(path.resolve("a/b/c/docs/toc.md"));
+	});
+	it("uses cwd from context", () => {
+		const cwd = os.homedir();
+		expect(fn.call({ cwd }, "a/b/c/package.json")).toBe(
+			path.resolve(cwd, "a/b/c/package.json"),
+		);
+	});
+	it("uses cwd from options", () => {
+		const cwd = os.tmpdir();
+		expect(fn("a/b", { data: { root: { cwd } } })).toBe(
+			path.resolve(cwd, "a/b"),
+		);
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("dirname", () => {
+	const fn = getHelper("dirname");
+	it("returns directory name", () => {
+		expect(fn("a/b/c/package.json")).toBe("a/b/c");
+		expect(fn("a/b/c/docs/toc.md")).toBe("a/b/c/docs");
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("relative", () => {
+	const fn = getHelper("relative");
+	it("returns relative path", () => {
+		expect(fn("dist/docs.html", "index.html")).toBe(
+			path.join("..", "index.html"),
+		);
+		expect(fn("examples/result/md/path.md", "examples/assets")).toBe(
+			path.join("..", "..", "assets"),
+		);
+	});
+	it("throws on invalid", () => {
+		expect(() =>
+			fn(undefined as unknown as string, undefined as unknown as string),
+		).toThrow("Expected first path to be of type string, but got undefined");
+		expect(() => fn("a", undefined as unknown as string)).toThrow(
+			"Expected second path to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("basename", () => {
+	const fn = getHelper("basename");
+	it("returns basename", () => {
+		expect(fn("a/b/c/package.json")).toBe("package.json");
+		expect(fn("a/b/c/CHANGELOG")).toBe("CHANGELOG");
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("stem", () => {
+	const fn = getHelper("stem");
+	it("returns stem", () => {
+		expect(fn("a/b/c/package.json")).toBe("package");
+		expect(fn("CHANGELOG")).toBe("CHANGELOG");
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("extname", () => {
+	const fn = getHelper("extname");
+	it("returns extension", () => {
+		expect(fn("a/b/c/package.json")).toBe(".json");
+		expect(fn("a/b/c/CHANGELOG")).toBe("");
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("resolve", () => {
+	const fn = getHelper("resolve");
+	it("resolves path", () => {
+		expect(fn("..", "test")).toBe(path.resolve("..", "test"));
+	});
+	it("uses context cwd", () => {
+		const cwd = "/tmp";
+		expect(fn.call({ cwd }, "foo")).toBe(path.resolve(cwd, "foo"));
+	});
+	it("uses options cwd", () => {
+		const cwd = os.tmpdir();
+		expect(fn("foo", { data: { root: { cwd } } })).toBe(
+			path.resolve(cwd, "foo"),
+		);
+	});
+	it("throws on invalid", () => {
+		expect(() => fn(undefined as unknown as string)).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});
+
+describe("segments", () => {
+	const fn = getHelper("segments");
+	it("returns segments", () => {
+		expect(fn("a/b/c/e.js", 1, 3)).toBe("b/c");
+		expect(fn("a/b/c/e.js", 0, 3)).toBe("a/b/c");
+	});
+	it("throws on invalid filepath", () => {
+		expect(() => fn(undefined as unknown as string, "2", "3")).toThrow(
+			"Expected filepath to be of type string, but got undefined",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add TypeScript path helper functions with type checking
- register path helpers in helper registry
- add comprehensive path helper tests and coverage

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68977368448c83249110a153fd18027f