### PR TITLE
feat: add regex helper

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -17,6 +17,7 @@ import { helpers as miscHelpers } from "./helpers/misc.js";
 import { helpers as numberHelpers } from "./helpers/number.js";
 import { helpers as objectHelpers } from "./helpers/object.js";
 import { helpers as pathHelpers } from "./helpers/path.js";
+import { helpers as regexHelpers } from "./helpers/regex.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -78,6 +79,8 @@ export class HelperRegistry {
 		this.registerHelpers(numberHelpers);
 		// Path
 		this.registerHelpers(pathHelpers);
+		// Regex
+		this.registerHelpers(regexHelpers);
 		// Object
 		this.registerHelpers(objectHelpers);
 	}

--- a/src/helpers/regex.ts
+++ b/src/helpers/regex.ts
@@ -1,0 +1,25 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
+import util from "handlebars-utils";
+import type { Helper } from "../helper-registry.js";
+
+const toRegex = (str: string, locals?: any, options?: any): RegExp => {
+	const opts = util.options({}, locals, options);
+	return new RegExp(str, opts.flags);
+};
+
+const test = (str: unknown, regex: RegExp): boolean => {
+	if (typeof str !== "string") {
+		return false;
+	}
+	if (!(regex instanceof RegExp)) {
+		throw new TypeError("expected a regular expression");
+	}
+	return regex.test(str);
+};
+
+export const helpers: Helper[] = [
+	{ name: "toRegex", category: "regex", fn: toRegex as any },
+	{ name: "test", category: "regex", fn: test as any },
+];
+
+export { toRegex, test };

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -53,6 +53,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("extend")).toBeTruthy();
 	});
+	test("includes regex helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("toRegex")).toBeTruthy();
+	});
 });
 
 describe("HelperRegistry Register", () => {
@@ -82,43 +86,43 @@ describe("HelperRegistry Filter", () => {
 	test("should return nothing filter by name", () => {
 		const registry = new HelperRegistry();
 		registry.register({
-			name: "test",
-			category: "test",
-			fn: () => "test",
+			name: "demo",
+			category: "demo",
+			fn: () => "demo",
 		});
-		expect(registry.filter({ name: "test1" }).length).toBe(0);
+		expect(registry.filter({ name: "demo1" }).length).toBe(0);
 	});
 	test("should filter by name", () => {
 		const registry = new HelperRegistry();
 		registry.register({
-			name: "test",
-			category: "test",
-			fn: () => "test",
+			name: "demo",
+			category: "demo",
+			fn: () => "demo",
 		});
-		expect(registry.filter({ name: "test" }).length).toBe(1);
+		expect(registry.filter({ name: "demo" }).length).toBe(1);
 	});
 	test("should filter by category", () => {
 		const registry = new HelperRegistry();
 		registry.register({
-			name: "test",
-			category: "test",
-			fn: () => "test",
+			name: "demo",
+			category: "demo",
+			fn: () => "demo",
 		});
 		registry.register({
-			name: "test2",
-			category: "test2",
-			fn: () => "test2",
+			name: "demo2",
+			category: "demo2",
+			fn: () => "demo2",
 		});
-		expect(registry.filter({ category: "test" }).length).toBe(1);
+		expect(registry.filter({ category: "demo" }).length).toBe(1);
 	});
 
 	test("should filter by compatibility", () => {
 		const registry = new HelperRegistry();
 		registry.register({
-			name: "test",
-			category: "test",
+			name: "demo",
+			category: "demo",
 			compatibility: HelperRegistryCompatibility.BROWSER,
-			fn: () => "test",
+			fn: () => "demo",
 		});
 		expect(
 			registry.filter({ compatibility: HelperRegistryCompatibility.BROWSER })

--- a/test/helpers/regex.test.ts
+++ b/test/helpers/regex.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/regex.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+const toRegexFn = getHelper("toRegex");
+const testFn = getHelper("test");
+
+describe("toRegex", () => {
+	it("creates a regular expression from a string", () => {
+		const result = toRegexFn("foo") as RegExp;
+		expect(result).toBeInstanceOf(RegExp);
+		expect(result.source).toBe("foo");
+	});
+	it("accepts flags", () => {
+		const result = toRegexFn("foo", { flags: "i" }) as RegExp;
+		expect(result.flags).toBe("i");
+	});
+});
+
+describe("test", () => {
+	it("returns false for non-string input", () => {
+		expect(testFn(123, /foo/)).toBe(false);
+	});
+	it("throws when regex is not a RegExp", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: testing invalid input
+		expect(() => testFn("foo", "bar" as any)).toThrow(
+			"expected a regular expression",
+		);
+	});
+	it("tests a string against a regex", () => {
+		const regex = toRegexFn("foo") as RegExp;
+		expect(testFn("foobar", regex)).toBe(true);
+		expect(testFn("bar", regex)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- convert regex helper to TypeScript
- cover regex helper with tests and add to registry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68979270c9888324841776168bec27a1