### PR TITLE
feat: add string helpers

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -18,6 +18,7 @@ import { helpers as numberHelpers } from "./helpers/number.js";
 import { helpers as objectHelpers } from "./helpers/object.js";
 import { helpers as pathHelpers } from "./helpers/path.js";
 import { helpers as regexHelpers } from "./helpers/regex.js";
+import { helpers as stringHelpers } from "./helpers/string.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -81,6 +82,8 @@ export class HelperRegistry {
 		this.registerHelpers(pathHelpers);
 		// Regex
 		this.registerHelpers(regexHelpers);
+		// String
+		this.registerHelpers(stringHelpers);
 		// Object
 		this.registerHelpers(objectHelpers);
 	}

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -1,0 +1,284 @@
+import type { Helper } from "../helper-registry.js";
+
+const chop = (str: string): string =>
+	str.trim().replace(/^[-_.\W\s]+|[-_.\W\s]+$/g, "");
+
+const changecase = (str: string, fn: (ch: string) => string): string => {
+	if (str.length === 1) return str.toLowerCase();
+	const res = chop(str).toLowerCase();
+	return res.replace(/[-_.\W\s]+(\w|$)/g, (_, ch) => fn(ch));
+};
+
+const append = (str: unknown, suffix: unknown): string | unknown => {
+	if (typeof str === "string" && typeof suffix === "string") {
+		return str + suffix;
+	}
+	return str as string;
+};
+
+const camelcase = (str: unknown): string =>
+	typeof str === "string" ? changecase(str, (ch) => ch.toUpperCase()) : "";
+
+const capitalize = (str: unknown): string => {
+	if (typeof str !== "string" || str.length === 0) return "";
+	return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+const capitalizeAll = (str: unknown): string => {
+	if (typeof str !== "string") return "";
+	return str.replace(/\w\S*/g, (word) => capitalize(word));
+};
+
+const center = (str: unknown, spaces: number): string => {
+	if (typeof str !== "string") return "";
+	let space = "";
+	for (let i = 0; i < spaces; i++) {
+		space += "&nbsp;";
+	}
+	return space + str + space;
+};
+
+const chopStr = (str: unknown): string =>
+	typeof str === "string" ? chop(str) : "";
+
+const dashcase = (str: unknown): string =>
+	typeof str === "string" ? changecase(str, (ch) => `-${ch}`) : "";
+
+const dotcase = (str: unknown): string =>
+	typeof str === "string" ? changecase(str, (ch) => `.${ch}`) : "";
+
+const truncate = (str: unknown, limit: number, suffix?: string): string => {
+	if (typeof str === "string") {
+		if (typeof suffix !== "string") {
+			suffix = "";
+		}
+		if (str.length > limit) {
+			return str.slice(0, limit - suffix.length) + suffix;
+		}
+		return str;
+	}
+	return "";
+};
+
+const ellipsis = (str: unknown, limit: number): string => {
+	if (typeof str === "string") {
+		if (str.length <= limit) {
+			return str;
+		}
+		return `${truncate(str, limit)}…`;
+	}
+	return "";
+};
+
+const hyphenate = (str: unknown): string =>
+	typeof str === "string" ? str.split(" ").join("-") : "";
+
+const isString = (value: unknown): boolean => typeof value === "string";
+
+const lowercase = (str: unknown): string => {
+	if (
+		typeof str === "object" &&
+		str !== null &&
+		"fn" in str &&
+		typeof (str as { fn: () => unknown }).fn === "function"
+	) {
+		return String((str as { fn: () => unknown }).fn()).toLowerCase();
+	}
+	if (typeof str !== "string") return "";
+	return str.toLowerCase();
+};
+
+const downcase = (...args: unknown[]): string => lowercase(...args);
+
+const occurrences = (str: unknown, substring: string): number | string => {
+	if (typeof str !== "string") return "";
+	const len = substring.length;
+	let pos = str.indexOf(substring, 0);
+	let n = 0;
+	while (pos > -1) {
+		n++;
+		pos = str.indexOf(substring, pos + len);
+	}
+	return n;
+};
+
+const pascalcase = (str: unknown): string => {
+	if (typeof str !== "string") return "";
+	const res = changecase(str, (ch) => ch.toUpperCase());
+	return res.charAt(0).toUpperCase() + res.slice(1);
+};
+
+const pathcase = (str: unknown): string =>
+	typeof str === "string" ? changecase(str, (ch) => `/${ch}`) : "";
+
+const plusify = (str: unknown, ch?: string): string => {
+	if (typeof str !== "string") return "";
+	if (typeof ch !== "string") ch = " ";
+	return str.split(ch).join("+");
+};
+
+const prepend = (str: unknown, prefix: unknown): string | unknown => {
+	return typeof str === "string" && typeof prefix === "string"
+		? prefix + str
+		: (str as unknown);
+};
+
+const remove = (str: unknown, ch: unknown): string => {
+	if (typeof str !== "string") return "";
+	if (typeof ch !== "string") return str;
+	return str.split(ch).join("");
+};
+
+const removeFirst = (str: unknown, ch: unknown): string => {
+	if (typeof str !== "string") return "";
+	if (typeof ch !== "string") return str;
+	return str.replace(ch, "");
+};
+
+const replace = (str: unknown, a: unknown, b?: unknown): string => {
+	if (typeof str !== "string") return "";
+	if (typeof a !== "string") return str;
+	if (typeof b !== "string") b = "";
+	return str.split(a).join(b as string);
+};
+
+const replaceFirst = (str: unknown, a: unknown, b?: unknown): string => {
+	if (typeof str !== "string") return "";
+	if (typeof a !== "string") return str;
+	if (typeof b !== "string") b = "";
+	return str.replace(a, b as string);
+};
+
+const reverse = (str: unknown): string =>
+	typeof str === "string" ? str.split("").reverse().join("") : "";
+
+const sentence = (str: unknown): string => {
+	if (typeof str !== "string") return "";
+	return str.replace(
+		/((?:\S[^.?!]*)[.?!]*)/g,
+		(txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase(),
+	);
+};
+
+const snakecase = (str: unknown): string =>
+	typeof str === "string" ? changecase(str, (ch) => `_${ch}`) : "";
+
+const trim = (str: unknown): string =>
+	typeof str === "string" ? str.trim() : "";
+
+const trimLeft = (str: unknown): string =>
+	typeof str === "string" ? str.replace(/^\s+/, "") : "";
+
+const trimRight = (str: unknown): string =>
+	typeof str === "string" ? str.replace(/\s+$/, "") : "";
+
+const truncateWords = (
+	str: unknown,
+	count: unknown,
+	suffix?: string,
+): string => {
+	if (
+		typeof str === "string" &&
+		typeof count === "number" &&
+		Number.isFinite(count)
+	) {
+		if (typeof suffix !== "string") {
+			suffix = "...";
+		}
+		const num = Math.trunc(count);
+		let arr = str.split(" ");
+		if (num < arr.length) {
+			arr = arr.slice(0, num);
+		}
+		const val = arr.join(" ").trim();
+		return val + suffix;
+	}
+	return "";
+};
+
+const truncateWordsAlias = truncateWords;
+
+const uppercase = (str: unknown): string => {
+	if (
+		typeof str === "object" &&
+		str !== null &&
+		"fn" in str &&
+		typeof (str as { fn: () => unknown }).fn === "function"
+	) {
+		return String((str as { fn: () => unknown }).fn()).toUpperCase();
+	}
+	if (typeof str !== "string") return "";
+	return str.toUpperCase();
+};
+
+const upcase = (...args: unknown[]): string => uppercase(...args);
+
+export const helpers: Helper[] = [
+	{ name: "append", category: "string", fn: append },
+	{ name: "camelcase", category: "string", fn: camelcase },
+	{ name: "capitalize", category: "string", fn: capitalize },
+	{ name: "capitalizeAll", category: "string", fn: capitalizeAll },
+	{ name: "center", category: "string", fn: center },
+	{ name: "chop", category: "string", fn: chopStr },
+	{ name: "dashcase", category: "string", fn: dashcase },
+	{ name: "dotcase", category: "string", fn: dotcase },
+	{ name: "ellipsis", category: "string", fn: ellipsis },
+	{ name: "hyphenate", category: "string", fn: hyphenate },
+	{ name: "isString", category: "string", fn: isString },
+	{ name: "lowercase", category: "string", fn: lowercase },
+	{ name: "downcase", category: "string", fn: downcase },
+	{ name: "occurrences", category: "string", fn: occurrences },
+	{ name: "pascalcase", category: "string", fn: pascalcase },
+	{ name: "pathcase", category: "string", fn: pathcase },
+	{ name: "plusify", category: "string", fn: plusify },
+	{ name: "prepend", category: "string", fn: prepend },
+	{ name: "remove", category: "string", fn: remove },
+	{ name: "removeFirst", category: "string", fn: removeFirst },
+	{ name: "replace", category: "string", fn: replace },
+	{ name: "replaceFirst", category: "string", fn: replaceFirst },
+	{ name: "reverse", category: "string", fn: reverse },
+	{ name: "sentence", category: "string", fn: sentence },
+	{ name: "snakecase", category: "string", fn: snakecase },
+	{ name: "trim", category: "string", fn: trim },
+	{ name: "trimLeft", category: "string", fn: trimLeft },
+	{ name: "trimRight", category: "string", fn: trimRight },
+	{ name: "truncate", category: "string", fn: truncate },
+	{ name: "truncateWords", category: "string", fn: truncateWordsAlias },
+	{ name: "uppercase", category: "string", fn: uppercase },
+	{ name: "upcase", category: "string", fn: upcase },
+];
+
+export {
+	append,
+	camelcase,
+	capitalize,
+	capitalizeAll,
+	center,
+	chopStr as chop,
+	dashcase,
+	dotcase,
+	ellipsis,
+	hyphenate,
+	isString,
+	lowercase,
+	downcase,
+	occurrences,
+	pascalcase,
+	pathcase,
+	plusify,
+	prepend,
+	remove,
+	removeFirst,
+	replace,
+	replaceFirst,
+	reverse,
+	sentence,
+	snakecase,
+	trim,
+	trimLeft,
+	trimRight,
+	truncate,
+	truncateWordsAlias as truncateWords,
+	uppercase,
+	upcase,
+};

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -49,6 +49,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("basename")).toBeTruthy();
 	});
+	test("includes string helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("camelcase")).toBeTruthy();
+	});
 	test("includes object helpers by default", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("extend")).toBeTruthy();

--- a/test/helpers/string.test.ts
+++ b/test/helpers/string.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/string.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("append", () => {
+	const fn = getHelper("append");
+	it("appends suffix", () => {
+		expect(fn("foo", "bar")).toBe("foobar");
+	});
+	it("returns original when not strings", () => {
+		expect(fn(1 as unknown, "bar")).toBe(1 as unknown);
+	});
+	it("returns original when suffix not string", () => {
+		expect(fn("foo", 1 as unknown)).toBe("foo");
+	});
+});
+
+describe("camelcase", () => {
+	const fn = getHelper("camelcase");
+	it("camelcases string", () => {
+		expect(fn("foo bar baz")).toBe("fooBarBaz");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(null)).toBe("");
+	});
+	it("handles single character", () => {
+		expect(fn("A")).toBe("a");
+	});
+});
+
+describe("capitalize", () => {
+	const fn = getHelper("capitalize");
+	it("capitalizes first letter", () => {
+		expect(fn("foo")).toBe("Foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(null)).toBe("");
+	});
+});
+
+describe("capitalizeAll", () => {
+	const fn = getHelper("capitalizeAll");
+	it("capitalizes all words", () => {
+		expect(fn("foo bar")).toBe("Foo Bar");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(undefined)).toBe("");
+	});
+});
+
+describe("center", () => {
+	const fn = getHelper("center");
+	it("centers string", () => {
+		expect(fn("foo", 2)).toBe("&nbsp;&nbsp;foo&nbsp;&nbsp;");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(null, 2)).toBe("");
+	});
+	it("handles zero spaces", () => {
+		expect(fn("foo", 0)).toBe("foo");
+	});
+});
+
+describe("chop", () => {
+	const fn = getHelper("chop");
+	it("chops non-word chars", () => {
+		expect(fn("_foo_")).toBe("foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("dashcase", () => {
+	const fn = getHelper("dashcase");
+	it("dashcases string", () => {
+		expect(fn("a b_c")).toBe("a-b-c");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn({} as unknown)).toBe("");
+	});
+});
+
+describe("dotcase", () => {
+	const fn = getHelper("dotcase");
+	it("dotcases string", () => {
+		expect(fn("a b_c")).toBe("a.b.c");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(true as unknown)).toBe("");
+	});
+});
+
+describe("ellipsis", () => {
+	const fn = getHelper("ellipsis");
+	it("returns string when shorter", () => {
+		expect(fn("foo", 5)).toBe("foo");
+	});
+	it("adds ellipsis when longer", () => {
+		expect(fn("foobar", 3)).toBe("foo…");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, 2)).toBe("");
+	});
+});
+
+describe("hyphenate", () => {
+	const fn = getHelper("hyphenate");
+	it("replaces spaces with hyphen", () => {
+		expect(fn("foo bar")).toBe("foo-bar");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(5 as unknown)).toBe("");
+	});
+});
+
+describe("isString", () => {
+	const fn = getHelper("isString");
+	it("detects strings", () => {
+		expect(fn("foo")).toBe(true);
+		expect(fn(1)).toBe(false);
+	});
+});
+
+describe("lowercase", () => {
+	const fn = getHelper("lowercase");
+	it("lowercases string", () => {
+		expect(fn("FOO")).toBe("foo");
+	});
+	it("handles block options", () => {
+		expect(fn({ fn: () => "BAR" })).toBe("bar");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(1 as unknown)).toBe("");
+	});
+});
+
+describe("downcase", () => {
+	const fn = getHelper("downcase");
+	it("aliases lowercase", () => {
+		expect(fn("FOO")).toBe("foo");
+	});
+});
+
+describe("occurrences", () => {
+	const fn = getHelper("occurrences");
+	it("counts substring", () => {
+		expect(fn("foo bar foo", "foo")).toBe(2);
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, "a")).toBe("");
+	});
+});
+
+describe("pascalcase", () => {
+	const fn = getHelper("pascalcase");
+	it("pascalcases string", () => {
+		expect(fn("foo bar")).toBe("FooBar");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(null)).toBe("");
+	});
+});
+
+describe("pathcase", () => {
+	const fn = getHelper("pathcase");
+	it("pathcases string", () => {
+		expect(fn("a b_c")).toBe("a/b/c");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("plusify", () => {
+	const fn = getHelper("plusify");
+	it("replaces spaces with plus", () => {
+		expect(fn("foo bar")).toBe("foo+bar");
+	});
+	it("uses custom char", () => {
+		expect(fn("foo-bar", "-")).toBe("foo+bar");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("prepend", () => {
+	const fn = getHelper("prepend");
+	it("prepends string", () => {
+		expect(fn("bar", "foo-")).toBe("foo-bar");
+	});
+	it("returns original when invalid", () => {
+		expect(fn(5 as unknown, "foo")).toBe(5 as unknown);
+	});
+	it("returns original when prefix invalid", () => {
+		expect(fn("bar", 1 as unknown)).toBe("bar");
+	});
+});
+
+describe("remove", () => {
+	const fn = getHelper("remove");
+	it("removes substring", () => {
+		expect(fn("a b a", "a ")).toBe("b a");
+	});
+	it("returns str when ch missing", () => {
+		expect(fn("abc", 1 as unknown)).toBe("abc");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, "a")).toBe("");
+	});
+});
+
+describe("removeFirst", () => {
+	const fn = getHelper("removeFirst");
+	it("removes first occurrence", () => {
+		expect(fn("a a a", "a")).toBe(" a a");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, "a")).toBe("");
+	});
+	it("returns str when ch not string", () => {
+		expect(fn("abc", 1 as unknown)).toBe("abc");
+	});
+});
+
+describe("replace", () => {
+	const fn = getHelper("replace");
+	it("replaces all occurrences", () => {
+		expect(fn("a a", "a", "b")).toBe("b b");
+	});
+	it("handles missing b", () => {
+		expect(fn("a a", "a")).toBe(" ");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, "a", "b")).toBe("");
+	});
+	it("returns str when a not string", () => {
+		expect(fn("a", 2 as unknown, "b")).toBe("a");
+	});
+});
+
+describe("replaceFirst", () => {
+	const fn = getHelper("replaceFirst");
+	it("replaces first occurrence", () => {
+		expect(fn("a a", "a", "b")).toBe("b a");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, "a", "b")).toBe("");
+	});
+	it("returns str when a not string", () => {
+		expect(fn("a", 2 as unknown, "b")).toBe("a");
+	});
+	it("handles missing b", () => {
+		expect(fn("a a", "a")).toBe(" a");
+	});
+});
+
+describe("reverse", () => {
+	const fn = getHelper("reverse");
+	it("reverses string", () => {
+		expect(fn("abc")).toBe("cba");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("sentence", () => {
+	const fn = getHelper("sentence");
+	it("sentence cases text", () => {
+		expect(fn("hello world. goodbye world.")).toBe(
+			"Hello world. Goodbye world.",
+		);
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("snakecase", () => {
+	const fn = getHelper("snakecase");
+	it("snakecases string", () => {
+		expect(fn("a b-c")).toBe("a_b_c");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("trim", () => {
+	const fn = getHelper("trim");
+	it("trims string", () => {
+		expect(fn("  foo  ")).toBe("foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("trimLeft", () => {
+	const fn = getHelper("trimLeft");
+	it("trims left", () => {
+		expect(fn("  foo")).toBe("foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("trimRight", () => {
+	const fn = getHelper("trimRight");
+	it("trims right", () => {
+		expect(fn("foo  ")).toBe("foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(false as unknown)).toBe("");
+	});
+});
+
+describe("truncate", () => {
+	const fn = getHelper("truncate");
+	it("truncates with suffix", () => {
+		expect(fn("foobar", 5, "...")).toBe("fo...");
+	});
+	it("returns str when shorter", () => {
+		expect(fn("foo", 5)).toBe("foo");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown, 2)).toBe("");
+	});
+});
+
+describe("truncateWords", () => {
+	const fn = getHelper("truncateWords");
+	it("truncates words", () => {
+		expect(fn("foo bar baz", 2)).toBe("foo bar...");
+	});
+	it("returns empty for invalid args", () => {
+		expect(fn("foo", "x" as unknown as number)).toBe("");
+	});
+});
+
+describe("uppercase", () => {
+	const fn = getHelper("uppercase");
+	it("uppercases string", () => {
+		expect(fn("foo")).toBe("FOO");
+	});
+	it("handles block", () => {
+		expect(fn({ fn: () => "bar" })).toBe("BAR");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});
+
+describe("upcase", () => {
+	const fn = getHelper("upcase");
+	it("aliases uppercase", () => {
+		expect(fn("foo")).toBe("FOO");
+	});
+	it("returns empty for non-string", () => {
+		expect(fn(123 as unknown)).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary
- add comprehensive string helper implementations in TypeScript
- register string helpers in the helper registry
- cover string helpers with thorough unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68979749a12c8324a1147fbd0761a977