### PR TITLE
Add TypeScript URL helper with full test coverage

### DIFF
--- a/src/helper-registry.ts
+++ b/src/helper-registry.ts
@@ -19,6 +19,7 @@ import { helpers as objectHelpers } from "./helpers/object.js";
 import { helpers as pathHelpers } from "./helpers/path.js";
 import { helpers as regexHelpers } from "./helpers/regex.js";
 import { helpers as stringHelpers } from "./helpers/string.js";
+import { helpers as urlHelpers } from "./helpers/url.js";
 
 export enum HelperRegistryCompatibility {
 	NODEJS = "nodejs",
@@ -84,6 +85,8 @@ export class HelperRegistry {
 		this.registerHelpers(regexHelpers);
 		// String
 		this.registerHelpers(stringHelpers);
+		// Url
+		this.registerHelpers(urlHelpers);
 		// Object
 		this.registerHelpers(objectHelpers);
 	}

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,73 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: this is for handlebars
+import { escape as qsEscape } from "node:querystring";
+import { format, parse, resolve } from "node:url";
+import type { Helper } from "../helper-registry.js";
+
+const encodeUri = (str: unknown): string | undefined => {
+	if (typeof str === "string") {
+		return encodeURIComponent(str);
+	}
+};
+
+const escapeFn = (str: unknown): string | undefined => {
+	if (typeof str === "string") {
+		return qsEscape(str);
+	}
+};
+
+const decodeUri = (str: unknown): string | undefined => {
+	if (typeof str === "string") {
+		return decodeURIComponent(str);
+	}
+};
+
+function urlEncode(this: unknown, ...args: unknown[]) {
+	return encodeUri.apply(this, args as [unknown]);
+}
+
+function urlDecode(this: unknown, ...args: unknown[]) {
+	return decodeUri.apply(this, args as [unknown]);
+}
+
+const urlResolve = (base: unknown, href: unknown): string =>
+	resolve(String(base), String(href));
+
+const urlParse = (str: unknown) => parse(String(str));
+
+const stripQuerystring = (str: unknown): string | undefined => {
+	if (typeof str === "string") {
+		return str.split("?")[0];
+	}
+};
+
+const stripProtocol = (str: unknown): string | undefined => {
+	if (typeof str === "string") {
+		const parsed = parse(str);
+		parsed.protocol = "";
+		return format(parsed);
+	}
+};
+
+export const helpers: Helper[] = [
+	{ name: "encodeURI", category: "url", fn: encodeUri as any },
+	{ name: "escape", category: "url", fn: escapeFn as any },
+	{ name: "decodeURI", category: "url", fn: decodeUri as any },
+	{ name: "url_encode", category: "url", fn: urlEncode as any },
+	{ name: "url_decode", category: "url", fn: urlDecode as any },
+	{ name: "urlResolve", category: "url", fn: urlResolve },
+	{ name: "urlParse", category: "url", fn: urlParse as any },
+	{ name: "stripQuerystring", category: "url", fn: stripQuerystring as any },
+	{ name: "stripProtocol", category: "url", fn: stripProtocol as any },
+];
+
+export {
+	encodeUri as encodeURI,
+	escapeFn as escape,
+	decodeUri as decodeURI,
+	urlEncode,
+	urlDecode,
+	urlResolve,
+	urlParse,
+	stripQuerystring,
+	stripProtocol,
+};

--- a/test/helpers/url.test.ts
+++ b/test/helpers/url.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { helpers } from "../../src/helpers/url.js";
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => {
+	const helper = helpers.find((h) => h.name === name);
+	if (!helper) throw new Error(`Helper ${name} not found`);
+	return helper.fn as HelperFn;
+};
+
+describe("encodeURI", () => {
+	const fn = getHelper("encodeURI");
+	it("encodes URI components", () => {
+		expect(fn("http://example.com?comment=Thyme &time=again")).toBe(
+			"http%3A%2F%2Fexample.com%3Fcomment%3DThyme%20%26time%3Dagain",
+		);
+	});
+	it("returns undefined for non-strings", () => {
+		expect(fn(123)).toBeUndefined();
+	});
+});
+
+describe("escape", () => {
+	const fn = getHelper("escape");
+	it("escapes a string", () => {
+		expect(fn("http://example.com?comment=Thyme &time=again")).toBe(
+			"http%3A%2F%2Fexample.com%3Fcomment%3DThyme%20%26time%3Dagain",
+		);
+	});
+	it("returns undefined for non-strings", () => {
+		expect(fn(123)).toBeUndefined();
+	});
+});
+
+describe("decodeURI", () => {
+	const fn = getHelper("decodeURI");
+	it("decodes URI components", () => {
+		expect(
+			fn("http%3A%2F%2Fexample.com%3Fcomment%3DThyme%20%26time%3Dagain"),
+		).toBe("http://example.com?comment=Thyme &time=again");
+	});
+	it("returns undefined for non-strings", () => {
+		expect(fn(123)).toBeUndefined();
+	});
+});
+
+describe("url_encode", () => {
+	const fn = getHelper("url_encode");
+	it("encodes using alias", () => {
+		expect(fn("http://example.com?comment=Thyme &time=again")).toBe(
+			"http%3A%2F%2Fexample.com%3Fcomment%3DThyme%20%26time%3Dagain",
+		);
+	});
+});
+
+describe("url_decode", () => {
+	const fn = getHelper("url_decode");
+	it("decodes using alias", () => {
+		expect(
+			fn("http%3A%2F%2Fexample.com%3Fcomment%3DThyme%20%26time%3Dagain"),
+		).toBe("http://example.com?comment=Thyme &time=again");
+	});
+});
+
+describe("urlResolve", () => {
+	const fn = getHelper("urlResolve");
+	it("resolves relative paths", () => {
+		expect(fn("/one/two/three", "four")).toBe("/one/two/four");
+		expect(fn("http://example.com/", "/one")).toBe("http://example.com/one");
+	});
+});
+
+describe("urlParse", () => {
+	const fn = getHelper("urlParse");
+	it("parses a url into components", () => {
+		expect(fn("http://foo.com/bar/baz?key=value")).toMatchObject({
+			protocol: "http:",
+			hostname: "foo.com",
+			pathname: "/bar/baz",
+			query: "key=value",
+		});
+	});
+});
+
+describe("stripQuerystring", () => {
+	const fn = getHelper("stripQuerystring");
+	it("strips query parameters", () => {
+		expect(fn("http://example.com?tests=true")).toBe("http://example.com");
+	});
+	it("returns undefined for non-strings", () => {
+		expect(fn(null)).toBeUndefined();
+	});
+});
+
+describe("stripProtocol", () => {
+	const fn = getHelper("stripProtocol");
+	it("removes http/https protocols", () => {
+		expect(fn("http://foo.bar")).toBe("//foo.bar/");
+		expect(fn("https://foo.bar")).toBe("//foo.bar/");
+	});
+	it("returns undefined for non-strings", () => {
+		expect(fn(123)).toBeUndefined();
+	});
+	it("leaves relative urls", () => {
+		expect(fn("/path/to/file")).toBe("/path/to/file");
+	});
+});


### PR DESCRIPTION
## Summary
- implement URL utility helpers in TypeScript
- register URL helpers with helper registry
- add comprehensive tests for URL helpers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e00a35c8324a17a6c0274f90ece