### PR TITLE
feat: add markdown helper

### DIFF
--- a/src/helpers/md.ts
+++ b/src/helpers/md.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import ent from "ent";
 import Handlebars from "handlebars";
 import { Remarkable } from "remarkable";
 import type { Helper } from "../helper-registry.js";
@@ -24,7 +25,7 @@ const renderMarkdown = (
 		string_ = fs.readFileSync(filepath, "utf8");
 	}
 
-	return new Handlebars.SafeString(md.render(string_));
+	return new Handlebars.SafeString(ent.decode(md.render(string_)));
 };
 
 export const helpers: Helper[] = [

--- a/test/helper-registry.test.ts
+++ b/test/helper-registry.test.ts
@@ -31,6 +31,10 @@ describe("HelperRegistry", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("attr")).toBeTruthy();
 	});
+	test("includes markdown helpers by default", () => {
+		const registry = new HelperRegistry();
+		expect(registry.has("md")).toBeTruthy();
+	});
 	test("includes i18n helpers by default", () => {
 		const registry = new HelperRegistry();
 		expect(registry.has("i18n")).toBeTruthy();

--- a/test/helpers/md.test.ts
+++ b/test/helpers/md.test.ts
@@ -28,4 +28,10 @@ describe("md helper", () => {
 		expect(result.toHTML()).toBe("<h1>File</h1>\n");
 		fs.rmSync(temporaryDir, { recursive: true, force: true });
 	});
+
+	it("should decode HTML entities", () => {
+		const mdHelper = helpers.find((helper) => helper.name === "md");
+		const result = mdHelper?.fn("&amp;") as Handlebars.SafeString;
+		expect(result.toHTML()).toBe("<p>&</p>\n");
+	});
 });


### PR DESCRIPTION
## Summary
- add ent decoding to markdown helper and expose in helper registry
- test markdown helper rendering and html entity decoding

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6898da4d71048324996db70800f0c170