### PR TITLE
fix: default import for handlebars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as HandlebarsLib from "handlebars";
+import HandlebarsLib from "handlebars";
 import { HelperFilter, HelperRegistry } from "./helper-registry.js";
 
 /**


### PR DESCRIPTION
## Summary
- use default import of `handlebars` so ESM and CommonJS consumers can call `create`

## Testing
- `pnpm test`
- `node -e "import('./dist/index.js').then(m=>console.log('esm ok', typeof m.fumanchu))"`
- `node -e "require('./dist/index.cjs'); console.log('cjs ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3f45c608324993b800adf4f5701