### PR TITLE
Ensure new Handlebars instances include existing partials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export function helpers(options: HelpersOptions) {
 export async function createHandlebars() {
 	const registry = new HelperRegistry();
 	const handlebars = HandlebarsLib.create();
+	if (Object.keys(HandlebarsLib.partials).length > 0) {
+		handlebars.registerPartial(HandlebarsLib.partials);
+	}
 	registry.load(handlebars);
 
 	/* c8 ignore start */
@@ -83,6 +86,8 @@ export function fumanchu(options?: FumanchuOptions) {
 	let handlebars = HandlebarsLib.create();
 	if (options?.handlebars) {
 		handlebars = options.handlebars;
+	} else if (Object.keys(HandlebarsLib.partials).length > 0) {
+		handlebars.registerPartial(HandlebarsLib.partials);
 	}
 	registry.load(handlebars);
 	return handlebars;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+import Handlebars from "handlebars";
 import { describe, expect, test } from "vitest";
 import {
 	createHandlebars,
@@ -56,10 +57,32 @@ describe("fumanchu", () => {
 		expect(result({})).toBe(new Date().getFullYear().toString());
 	});
 
+	test("fumanchu should include existing partials", () => {
+		Handlebars.registerPartial("fumanchuPartial", "Hello {{name}}");
+		try {
+			const instance = fumanchu();
+			const template = instance.compile("{{> fumanchuPartial}}");
+			expect(template({ name: "World" })).toBe("Hello World");
+		} finally {
+			Handlebars.unregisterPartial("fumanchuPartial");
+		}
+	});
+
 	test("should be able to do markdown", async () => {
 		const handlebars = await createHandlebars();
 		expect(handlebars).toBeDefined();
 		const result = handlebars.compile('{{md "# Hello World"}}');
 		expect(result({})).toBe("<h1>Hello World</h1>\n");
+	});
+
+	test("createHandlebars should include existing partials", async () => {
+		Handlebars.registerPartial("fumanchuCreatePartial", "Hi {{name}}");
+		try {
+			const instance = await createHandlebars();
+			const template = instance.compile("{{> fumanchuCreatePartial}}");
+			expect(template({ name: "World" })).toBe("Hi World");
+		} finally {
+			Handlebars.unregisterPartial("fumanchuCreatePartial");
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- ensure `createHandlebars` and `fumanchu` copy over any partials registered on the base Handlebars instance
- add regression tests proving that partials registered before creating new instances are rendered correctly

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc73bb70748324951070b2b7791d5b