### PR TITLE
Add array forEach helper and tests

### DIFF
--- a/test/helpers/array.test.ts
+++ b/test/helpers/array.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ForEachOptions } from "../../src/helpers/array.js";
 import { helpers } from "../../src/helpers/array.js";
 
 type HelperFn = (...args: unknown[]) => unknown;
@@ -91,5 +92,131 @@ describe("join", () => {
 	});
 	it("returns empty string for non-string/non-array", () => {
 		expect(joinFn(123)).toBe("");
+	});
+});
+
+describe("forEach", () => {
+	type ForEachHelper = (
+		this: unknown,
+		collection: unknown,
+		options?: ForEachOptions<Record<string, unknown>>,
+	) => string;
+
+	const forEachFn = getHelper("forEach") as ForEachHelper;
+
+	it("iterates arrays and exposes metadata", () => {
+		const accounts = [
+			{ name: "John", email: "john@example.com" },
+			{ name: "Malcolm", email: "malcolm@example.com" },
+			{ name: "David", email: "david@example.com" },
+		];
+
+		const contexts: Array<Record<string, unknown>> = [];
+
+		const result = forEachFn.call({ company: "Initech" }, accounts, {
+			hash: { company: "Initech" },
+			data: { root: { description: "accounts" } },
+			fn(context) {
+				const account = context as {
+					name: string;
+					email: string;
+					index: number;
+					total: number;
+					isFirst: boolean;
+					isLast: boolean;
+					company: string;
+				};
+
+				contexts.push({
+					name: account.name,
+					email: account.email,
+					index: account.index,
+					total: account.total,
+					isFirst: account.isFirst,
+					isLast: account.isLast,
+					company: account.company,
+				});
+				return account.name;
+			},
+		});
+
+		expect(result).toBe("JohnMalcolmDavid");
+		expect(contexts).toEqual([
+			{
+				name: "John",
+				email: "john@example.com",
+				index: 0,
+				total: 3,
+				isFirst: true,
+				isLast: false,
+				company: "Initech",
+			},
+			{
+				name: "Malcolm",
+				email: "malcolm@example.com",
+				index: 1,
+				total: 3,
+				isFirst: false,
+				isLast: false,
+				company: "Initech",
+			},
+			{
+				name: "David",
+				email: "david@example.com",
+				index: 2,
+				total: 3,
+				isFirst: false,
+				isLast: true,
+				company: "Initech",
+			},
+		]);
+	});
+
+	it("provides private data frame values", () => {
+		const indexes: Array<number | undefined> = [];
+		const totals: Array<number | undefined> = [];
+		const extras: Array<string | undefined> = [];
+
+		forEachFn.call({}, ["alpha", "beta"], {
+			hash: { extra: "value" },
+			data: { root: { type: "strings" } },
+			fn: (_context, frame) => {
+				indexes.push(frame?.data?.index as number | undefined);
+				totals.push(frame?.data?.total as number | undefined);
+				extras.push(frame?.data?.extra as string | undefined);
+				return "";
+			},
+		});
+
+		expect(indexes).toEqual([0, 1]);
+		expect(totals).toEqual([2, 2]);
+		expect(extras).toEqual(["value", "value"]);
+	});
+
+	it("renders inverse block when collection is missing or empty", () => {
+		let inverseContext: unknown;
+		const inverseResult = forEachFn.call({ foo: "bar" }, undefined, {
+			inverse(context?: unknown) {
+				inverseContext = context;
+				return "inverse";
+			},
+		});
+
+		expect(inverseResult).toBe("inverse");
+		expect(inverseContext).toEqual({ foo: "bar" });
+
+		let fnCalled = false;
+		const emptyResult = forEachFn.call({}, [], {
+			fn() {
+				fnCalled = true;
+				return "";
+			},
+			inverse() {
+				return "empty";
+			},
+		});
+
+		expect(emptyResult).toBe("empty");
+		expect(fnCalled).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- implement the array `forEach` helper with context metadata, hash support, and inverse handling
- register the helper and export its option type for reuse
- add coverage that exercises metadata exposure, private data frames, and inverse fallback behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc95c792a4832488cc0fc066226b59