### PR TITLE
fix: replace striptags dependency with inline implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "handlebars": "^4.7.9",
     "micromatch": "^4.0.8",
     "remarkable": "^2.0.1",
-    "striptags": "^3.2.0",
     "to-gfm-code-block": "^0.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       remarkable:
         specifier: ^2.0.1
         version: 2.0.1
-      striptags:
-        specifier: ^3.2.0
-        version: 3.2.0
       to-gfm-code-block:
         specifier: ^0.1.1
         version: 0.1.1

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,8 +1,45 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: handlebars helpers use any for context
 import path from "node:path";
-import striptags from "striptags";
 import type { Helper } from "../helper-registry.js";
 import { arrayify } from "./array.js";
+
+const stripTags = (str: string): string => {
+	let result = "";
+	let inTag = false;
+	let inComment = false;
+	let quote: '"' | "'" | null = null;
+	for (let i = 0; i < str.length; i++) {
+		const ch = str[i];
+		if (inComment) {
+			if (ch === "-" && str[i + 1] === "-" && str[i + 2] === ">") {
+				inComment = false;
+				i += 2;
+			}
+			continue;
+		}
+		if (inTag) {
+			if (quote) {
+				if (ch === quote) quote = null;
+			} else if (ch === '"' || ch === "'") {
+				quote = ch;
+			} else if (ch === ">") {
+				inTag = false;
+			}
+			continue;
+		}
+		if (ch === "<") {
+			if (str[i + 1] === "!" && str[i + 2] === "-" && str[i + 3] === "-") {
+				inComment = true;
+				i += 3;
+				continue;
+			}
+			inTag = true;
+			continue;
+		}
+		result += ch;
+	}
+	return result;
+};
 
 const VOID_ELEMENTS = new Set([
 	"area",
@@ -127,7 +164,7 @@ const js = (context: any): string => {
 
 const sanitize = (str?: string): string => {
 	if (typeof str !== "string") return "";
-	return striptags(str).trim();
+	return stripTags(str).trim();
 };
 
 const ul = (

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import type { Helper } from "../helper-registry.js";
 import { arrayify } from "./array.js";
 
+const isTagStart = (ch: string | undefined): boolean =>
+	ch !== undefined &&
+	(ch === "/" || ch === "!" || ch === "?" || /[a-zA-Z]/.test(ch));
+
 const stripTags = (str: string): string => {
 	let result = "";
 	let inTag = false;
@@ -33,8 +37,10 @@ const stripTags = (str: string): string => {
 				i += 3;
 				continue;
 			}
-			inTag = true;
-			continue;
+			if (isTagStart(str[i + 1])) {
+				inTag = true;
+				continue;
+			}
 		}
 		result += ch;
 	}

--- a/test/helpers/html.test.ts
+++ b/test/helpers/html.test.ts
@@ -176,6 +176,18 @@ describe("sanitize", () => {
 	it("preserves text between tags", () => {
 		expect(sanitizeFn("<b>hi</b> <i>there</i>")).toBe("hi there");
 	});
+	it("preserves inequality characters in text", () => {
+		expect(sanitizeFn("Use 1 < 2 and 3 > 2")).toBe("Use 1 < 2 and 3 > 2");
+	});
+	it("preserves < when followed by non-tag characters", () => {
+		expect(sanitizeFn("a<5")).toBe("a<5");
+	});
+	it("preserves a trailing <", () => {
+		expect(sanitizeFn("foo<")).toBe("foo<");
+	});
+	it("preserves text content inside script tags", () => {
+		expect(sanitizeFn("<script>if (a < b)</script>")).toBe("if (a < b)");
+	});
 });
 
 describe("ul", () => {

--- a/test/helpers/html.test.ts
+++ b/test/helpers/html.test.ts
@@ -155,6 +155,27 @@ describe("sanitize", () => {
 	it("strips html from a string", () => {
 		expect(sanitizeFn("<span>foo</span>")).toBe("foo");
 	});
+	it("strips tags with attributes", () => {
+		expect(sanitizeFn('<a href="http://x.com" title="hi">foo</a>')).toBe("foo");
+	});
+	it("handles > inside double-quoted attribute values", () => {
+		expect(sanitizeFn('<a title="1>2">foo</a>')).toBe("foo");
+	});
+	it("handles > inside single-quoted attribute values", () => {
+		expect(sanitizeFn("<a title='1>2'>foo</a>")).toBe("foo");
+	});
+	it("ignores unterminated quotes until tag closes", () => {
+		expect(sanitizeFn('<a title="x>bar')).toBe("");
+	});
+	it("strips html comments", () => {
+		expect(sanitizeFn("foo<!-- secret -->bar")).toBe("foobar");
+	});
+	it("handles unterminated comments", () => {
+		expect(sanitizeFn("foo<!-- never ends")).toBe("foo");
+	});
+	it("preserves text between tags", () => {
+		expect(sanitizeFn("<b>hi</b> <i>there</i>")).toBe("hi there");
+	});
 });
 
 describe("ul", () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

Refactoring / Dependency Removal

**Description**

This PR removes the `striptags` npm dependency and replaces it with an inline implementation in `src/helpers/html.ts`. The new `stripTags` function provides the same functionality with proper handling of:
- HTML tags
- HTML comments
- Quoted attributes (both single and double quotes)

The implementation is more transparent and reduces external dependencies while maintaining the same behavior for the `sanitize` helper function.

**Changes**
- Removed `striptags` dependency from `package.json`
- Implemented custom `stripTags` function in `src/helpers/html.ts` that handles HTML tag removal with proper quote and comment handling
- Updated `sanitize` function to use the new `stripTags` implementation

**Test Plan**

Existing tests for the `sanitize` helper continue to pass, ensuring the new implementation maintains backward compatibility with the previous behavior.

https://claude.ai/code/session_013VPHb8TfPYzxK5n22SUXRr