### PR TITLE
root - chore: upgrade markdown-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "dayjs": "^1.11.20",
     "ent": "^2.2.2",
     "handlebars": "^4.7.9",
-    "markdown-it": "^14.1.0",
+    "markdown-it": "^14.2.0",
     "micromatch": "^4.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.7.9
         version: 4.7.9
       markdown-it:
-        specifier: ^14.1.0
-        version: 14.1.1
+        specifier: ^14.2.0
+        version: 14.2.0
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -1794,8 +1794,8 @@ packages:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   liquidjs@10.27.0:
     resolution: {integrity: sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==}
@@ -1822,8 +1822,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -3010,7 +3010,7 @@ snapshots:
       dayjs: 1.11.20
       ent: 2.2.2
       handlebars: 4.7.9
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       micromatch: 4.0.8
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -4180,7 +4180,7 @@ snapshots:
     dependencies:
       package-json: 10.0.1
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -4212,11 +4212,11 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0


### PR DESCRIPTION
## Summary
Upgrade the runtime `markdown-it` dependency to its latest `minimumReleaseAge`-gated version (first runtime-phase PR). This also clears a moderate advisory in a **shipped** dependency.

## Versions
- `markdown-it` `14.1.1` → `14.2.0`

## Security
- Resolves the moderate **quadratic-complexity DoS in the smartquotes rule** (vulnerable `<=14.1.1`, patched `>=14.1.2`), which affected the direct runtime `markdown-it`. `pnpm audit` now reports **0** markdown-it advisories.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test:ci` passes — 787 tests, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014c2syNTsrWhU2G5bGhNpPy

---
_Generated by [Claude Code](https://claude.ai/code/session_014c2syNTsrWhU2G5bGhNpPy)_