### PR TITLE
root - chore: upgrade dayjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@cacheable/memory": "^2.0.9",
     "chrono-node": "2.9.1",
-    "dayjs": "^1.11.20",
+    "dayjs": "^1.11.21",
     "ent": "^2.2.2",
     "handlebars": "^4.7.9",
     "markdown-it": "^14.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.9.1
         version: 2.9.1
       dayjs:
-        specifier: ^1.11.20
-        version: 1.11.20
+        specifier: ^1.11.21
+        version: 1.11.21
       ent:
         specifier: ^2.2.2
         version: 2.2.2
@@ -1304,8 +1304,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  dayjs@1.11.20:
-    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3008,7 +3008,7 @@ snapshots:
     dependencies:
       '@cacheable/memory': 2.0.9
       chrono-node: 2.9.0
-      dayjs: 1.11.20
+      dayjs: 1.11.21
       ent: 2.2.2
       handlebars: 4.7.9
       markdown-it: 14.2.0
@@ -3610,7 +3610,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  dayjs@1.11.20: {}
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade the runtime `dayjs` dependency to its latest `minimumReleaseAge`-gated version — the **final** runtime-phase PR (4 of 4).

## Versions
- `dayjs` `1.11.20` → `1.11.21`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test:ci` passes — 787 tests, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014c2syNTsrWhU2G5bGhNpPy

---
_Generated by [Claude Code](https://claude.ai/code/session_014c2syNTsrWhU2G5bGhNpPy)_