### PR TITLE
release: v4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jaredwray/fumanchu",
   "description": "Handlebars + Helpers = Fumanchu",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "packageManager": "pnpm@11.9.0",
   "homepage": "https://github.com/jaredwray/fumanchu",
   "author": "Jared Wray (me@jaredwray.com)",


### PR DESCRIPTION
## Release summary
Maintenance and security release: hardens the `md` helper against XSS, clears a markdown-it DoS advisory, and refreshes runtime and tooling dependencies. Bumps `@jaredwray/fumanchu` `4.7.0` → `4.7.1` (patch).

## @jaredwray/fumanchu@4.7.1 — 2026-06-23

Maintenance and security release: hardens the `md` helper against XSS, clears a markdown-it DoS advisory, and refreshes runtime and tooling dependencies.

### Security
- The `md`/`markdown` helper no longer HTML-entity-decodes its rendered output — markdown-it's escaping is now preserved (8c3c0f3, #230). The previous `decodeHTML(md.render(...))` step enabled attribute-breakout XSS (e.g. an alt-text payload injecting a live `onerror` handler) and corrupted URLs whose query params began with a legacy entity name (e.g. `&region`). The `ent` dependency was removed with no replacement.
  - **Behavior change:** entities in markdown output are now preserved rather than decoded.

    ```handlebars
    {{md "&amp;"}}
    {{!-- v4.7.0: <p>&</p>  →  v4.7.1: <p>&amp;</p> --}}
    ```
- Upgrade `markdown-it` 14.1.1 → 14.2.0 (12c0c49, #226), resolving a moderate quadratic-complexity DoS advisory in the smartquotes rule (a shipped runtime dependency).

### Internal
- Upgrade runtime dependencies: `@cacheable/memory` 2.0.8 → 2.0.9 (285e799, #227), `chrono-node` 2.9.0 → 2.9.1 (8507644, #228), `dayjs` 1.11.20 → 1.11.21 (30d1874, #229).
- Upgrade dev/build tooling: code-quality deps + migrate to pnpm 11 (416e012, #222), TypeScript and build tooling (d39c0bb, #223), `docula` 1.13.0 → 2.1.0 (965c78a, #225).
- Upgrade GitHub Actions to their latest major versions (5e5b1fe, #224).
- Publish to npm via OIDC trusted publishing with provenance, dropping the long-lived `NPM_TOKEN` (6bd13c2, #232).

### Documentation
- Add a GitHub repository link to the website top navigation (3ddbe20, #231).

### Contributors
- @jaredwray (11)

### Full List of Changes
- root - chore: upgrade code quality deps and migrate to pnpm 11 by @jaredwray in #222
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #223
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #224
- root - chore: upgrade docula to 2.x (breaking) by @jaredwray in #225
- root - chore: upgrade markdown-it by @jaredwray in #226
- root - chore: upgrade @cacheable/memory by @jaredwray in #227
- root - chore: upgrade chrono-node by @jaredwray in #228
- root - chore: upgrade dayjs by @jaredwray in #229
- feat: Replace ent with entities for HTML decoding by @jaredwray in #230
- Add GitHub repo link to website top navigation by @jaredwray in #231
- ci: publish to npm via OIDC trusted publishing with provenance by @jaredwray in #232

**Full diff:** https://github.com/jaredwray/fumanchu/compare/v4.7.0...v4.7.1

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 788 tests, 100% coverage
- [x] No uncommitted changes outside the version bump

## Post-merge
- Merge, then create a GitHub Release at tag `v4.7.1` — the `release.yml` workflow triggers on the `released` event and publishes to npm via OIDC trusted publishing with provenance.
- Requires the npm trusted-publisher config (added in #232) to be in place, or the publish step will fail auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lvbj163oDKo5VtdCMtLw2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvbj163oDKo5VtdCMtLw2k)_