### PR TITLE
fix(deploy-site): allow wrangler build scripts and set Cloudflare account ID

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -36,4 +36,5 @@ jobs:
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy site/dist --project-name=fumanchu --branch=main

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ minimumReleaseAge: 2880
 allowBuilds:
   esbuild: true
   unrs-resolver: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Problem

The `deploy-site` workflow started failing on the v4.7.1 release ([run #28051437693](https://github.com/jaredwray/fumanchu/actions/runs/28051437693)) with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, workerd@1.20260617.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
##[error]The process '.../pnpm' failed with exit code 1
##[error]🚨 Action failed
```

### Root cause

`cloudflare/wrangler-action@v4` does not find a local wrangler, so it installs one on the fly with `pnpm add wrangler@4`. That pulls in wrangler's dependencies `workerd` and `sharp`, both of which have post-install build scripts.

This repo opts into pnpm's supply-chain controls in `pnpm-workspace.yaml` (`minimumReleaseAge` + `allowBuilds`), and the `allowBuilds` allowlist only permitted `esbuild` and `unrs-resolver`. Because `workerd`/`sharp` weren't allowlisted, pnpm hard-errors with `ERR_PNPM_IGNORED_BUILDS` and exits `1`, failing the action. (Note `esbuild`/`unrs-resolver` are absent from the ignored list, confirming `allowBuilds` is the correct, respected key.)

## Changes

- **`pnpm-workspace.yaml`** — add `sharp` and `workerd` to `allowBuilds` so the wrangler install no longer fails on ignored build scripts.
- **`.github/workflows/deploy-site.yml`** — pass `accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}` to `wrangler-action@v4` so deploys target the correct Cloudflare account.

## Action required ⚠️

Add a repository secret named **`CLOUDFLARE_ACCOUNT_ID`** (Settings → Secrets and variables → Actions) with your Cloudflare account ID. The workflow references it via `${{ secrets.CLOUDFLARE_ACCOUNT_ID }}`; if the secret is absent it resolves to an empty string and wrangler will fall back to token-based account resolution.

## Verifying

The workflow runs on `release: [released]` and `workflow_dispatch`, so it can be re-run manually from the Actions tab to confirm the deploy succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lffg3WkNpgrGbmdxanA6Lk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lffg3WkNpgrGbmdxanA6Lk)_