### PR TITLE
root - chore: upgrade docula

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/micromatch": "^4.0.10",
     "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.10",
-    "docula": "^2.1.0",
+    "docula": "^2.2.0",
     "dotenv": "^17.4.2",
     "happy-dom": "^20.11.1",
     "rimraf": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       docula:
-        specifier: ^2.1.0
-        version: 2.1.0(chokidar@3.6.0)(zod@4.4.3)
+        specifier: ^2.2.0
+        version: 2.2.0(chokidar@3.6.0)(zod@4.4.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -560,12 +560,6 @@ packages:
     peerDependencies:
       tinybench: ^6.0.0
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -937,9 +931,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1427,8 +1418,8 @@ packages:
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
 
-  docula@2.1.0:
-    resolution: {integrity: sha512-lNsIM9ZaLU7+r7sHpHnBgjt6pOSl2Yc2QLbBrCvjLEn8SIlvnhLiXyQ7o4rmw+36CvSB/ZkF2QXABOpcyAM8nQ==}
+  docula@2.2.0:
+    resolution: {integrity: sha512-6/lIrtLZj0vf9fSkPXHxqAsLJaqDdS+7GSHxt+UkkouHF/FqTqaQZ3os/Q3tdX+NDVVg8/TQyPp7dHQOEoRfow==}
     engines: {node: ^22.19.0 || >=24.0.0}
     hasBin: true
 
@@ -3129,13 +3120,6 @@ snapshots:
       picocolors: 1.1.1
       tinybench: 6.0.2
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -3240,7 +3224,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3348,11 +3332,6 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -3771,7 +3750,7 @@ snapshots:
 
   doctypes@1.1.0: {}
 
-  docula@2.1.0(chokidar@3.6.0)(zod@4.4.3):
+  docula@2.2.0(chokidar@3.6.0)(zod@4.4.3):
     dependencies:
       '@ai-sdk/anthropic': 3.0.85(zod@4.4.3)
       '@ai-sdk/google': 3.0.83(zod@4.4.3)
@@ -3960,6 +3939,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fill-range@7.1.1:
     dependencies:
@@ -5530,8 +5513,8 @@ snapshots:
   vite@7.2.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.39.2)(tsx@4.23.1):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.17


### PR DESCRIPTION
## Summary
Upgrade the documentation site generator to its latest `minimumReleaseAge`-gated version. Minor bump — no config changes required.

## Versions
- `docula` `2.1.0` → `2.2.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 788 tests, 100% coverage
- [x] `pnpm lint:ci` passes (CI-equivalent, no `--write`)
- [x] `pnpm website:build` — docula 2.2.0 loads, parses `site/docula.config.ts`, and completes its prepare step (regenerates `site/docs/index.md` and the four project-guideline pages)

## Notes
- `pnpm website:build` cannot run to completion in this sandbox: it fails at `Github.getReleases` with `Fetch failed with status 401` because there is no GitHub token available for the releases API call. That is an environment limitation, not a docula regression — the same call is the known blocker noted in #231/#235. Everything up to that network call works, and the deploy runs on `release` with credentials.
- The docula-generated site files are gitignored, so this PR touches only `package.json` and `pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_