### PR TITLE
root - chore: upgrade pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jaredwray/fumanchu",
   "description": "Handlebars + Helpers = Fumanchu",
   "version": "4.7.1",
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.15.1",
   "homepage": "https://github.com/jaredwray/fumanchu",
   "author": "Jared Wray (me@jaredwray.com)",
   "type": "module",


### PR DESCRIPTION
## Summary
Third dev-phase group of the dependency-management process — the **package manager tooling** upgrade. Bumps the corepack-pinned `packageManager`; `pnpm/action-setup@v6` reads this field, so CI and local development both follow.

## Versions
- `pnpm` `11.9.0` → `11.15.1`

## Notes
- **`11.15.1` is the newest release that clears the repo's 48h `minimumReleaseAge` policy.** `11.16.0` (published `2026-07-22T20:17Z`) and `11.17.0` (`2026-07-23T16:59Z`) are both still inside that window and were deliberately skipped. `pnpm outdated` does not surface `packageManager`, so this was checked against the registry directly. `11.16.0` becomes eligible a couple of hours from now if you'd rather wait for it.
- Lockfile is untouched — `lockfileVersion` stays `9.0` and this PR changes only the one line in `package.json`.

## Tests
Verified locally by running the real 11.15.1 binary via `corepack pnpm@11.15.1`, not the ambient 11.9.0:
- [x] `pnpm install --frozen-lockfile` is a no-op ("Already up to date") — no lockfile churn under the new version
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 788 tests, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_