### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,7 +22,7 @@ jobs:
 
     # Test
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary
Final dev-phase group of the dependency-management process — the **GitHub Actions** upgrade. Only one action has a newer major available, so this is a 4-line diff. `(breaking)` denotes the major bump; the inputs this repo passes are verified compatible on v7.

## Versions
- `actions/setup-node` v6 → **v7** (4 workflows)

## Already on their latest major — unchanged
| Action | Pinned |
|---|---|
| `actions/checkout` | v7 |
| `pnpm/action-setup` | v6 |
| `codecov/codecov-action` | v7 |
| `github/codeql-action/{init,autobuild,analyze}` | v4 |
| `cloudflare/wrangler-action` | v4 |

The repo pins by major, so minor and patch releases in these are already picked up without a diff. Pin style is unchanged.

## Checks
- [x] All 5 workflow files parse (validated with `js-yaml`, jobs enumerated)
- [x] Every `uses:` still carries a ref
- [x] Inputs verified against v7's `action.yml`: `node-version` (all four workflows) and `registry-url` (`release.yml`) are both still defined; runtime is `node24`

## Breaking notes
`setup-node` v7 migrates to ESM, drops a dummy `NODE_AUTH_TOKEN` export, and adds `cache-primary-key`/`cache-matched-key` outputs. This repo passes only `node-version` and `registry-url` and reads none of the removed/added outputs, so no workflow logic changes are required.

One coverage gap worth flagging: PR-triggered workflows (`tests`, `code-coverage`) exercise `setup-node@v7` in this PR, but `release.yml` and `deploy-site.yml` only run on `release`, so their `setup-node` step isn't exercised here. `release.yml` is the one to watch — it pairs `registry-url` with OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_