### PR TITLE
root - chore: upgrade @cacheable/memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "license"
   ],
   "dependencies": {
-    "@cacheable/memory": "^2.0.9",
+    "@cacheable/memory": "^2.2.0",
     "chrono-node": "2.9.1",
     "dayjs": "^1.11.21",
     "handlebars": "^4.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@cacheable/memory':
-        specifier: ^2.0.9
-        version: 2.0.9
+        specifier: ^2.2.0
+        version: 2.2.0
       chrono-node:
         specifier: 2.9.1
         version: 2.9.1
@@ -190,14 +190,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cacheable/memory@2.0.9':
-    resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
   '@cacheable/net@2.0.8':
     resolution: {integrity: sha512-uSRwS6krnRsOM65F1S2IlkGQA+VoxkrbrkBwmbFxDj/ihdSHtDpLMIaKguM0A++dUXTha2cY146yNOqwv8gAPQ==}
 
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -2876,9 +2879,9 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
-  '@cacheable/memory@2.0.9':
+  '@cacheable/memory@2.2.0':
     dependencies:
-      '@cacheable/utils': 2.4.1
+      '@cacheable/utils': 2.5.0
       '@keyv/bigmap': 1.3.1(keyv@5.6.0)
       hookified: 1.15.1
       keyv: 5.6.0
@@ -2891,6 +2894,11 @@ snapshots:
       undici: 7.25.0
 
   '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
@@ -3071,7 +3079,7 @@ snapshots:
 
   '@jaredwray/fumanchu@4.7.0':
     dependencies:
-      '@cacheable/memory': 2.0.9
+      '@cacheable/memory': 2.2.0
       chrono-node: 2.9.0
       dayjs: 1.11.21
       ent: 2.2.2
@@ -3630,7 +3638,7 @@ snapshots:
 
   cacheable@2.3.5:
     dependencies:
-      '@cacheable/memory': 2.0.9
+      '@cacheable/memory': 2.2.0
       '@cacheable/utils': 2.4.1
       hookified: 1.15.1
       keyv: 5.6.0


### PR DESCRIPTION
## Summary
Second runtime-phase PR (2 of 3). Upgrades the in-memory cache backing the helper registry to its latest `minimumReleaseAge`-gated version.

## Versions
- `@cacheable/memory` `2.0.9` → `2.2.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 788 tests, 100% coverage
- [x] `CacheableMemory` public export spot-checked against the built bundle

## Notes
`CacheableMemory` is re-exported from the package entry point, so this bump touches public API surface rather than just internals. I exercised it against `dist/index.node.mjs`: `set`/`get` round-trips, `set` with a `ttl` option plus `has`, and `delete` all behave as before, and the prototype still carries the full method set (`get`, `getMany`, `getRaw`, `getManyRaw`, `set`, `setMany`, `has`, `hasMany`, `take`, `takeMany`, `delete`, `deleteMany`, `clear`). No surface change between 2.0.9 and 2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_