### PR TITLE
root - chore: upgrade chrono-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   ],
   "dependencies": {
     "@cacheable/memory": "^2.2.0",
-    "chrono-node": "2.9.1",
+    "chrono-node": "2.10.1",
     "dayjs": "^1.11.21",
     "handlebars": "^4.7.9",
     "markdown-it": "^14.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       chrono-node:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.10.1
+        version: 2.10.1
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
@@ -1332,12 +1332,12 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chrono-node@2.9.0:
-    resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
+  chrono-node@2.10.1:
+    resolution: {integrity: sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  chrono-node@2.9.1:
-    resolution: {integrity: sha512-nqP8Zp11efCYQIESXPxeDM8ikzN5BDb3Zzou+a66fZq+X2hzKFdsNLQE2/uBAh//BZEMbaMo1eTnagK7hOenAg==}
+  chrono-node@2.9.0:
+    resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-boxes@3.0.0:
@@ -3689,9 +3689,9 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
-  chrono-node@2.9.0: {}
+  chrono-node@2.10.1: {}
 
-  chrono-node@2.9.1: {}
+  chrono-node@2.9.0: {}
 
   cli-boxes@3.0.0: {}
 


### PR DESCRIPTION
## Summary
Final runtime-phase PR (3 of 3) — and the **last PR of this dependency-maintenance run**. Upgrades the natural-language date parser behind the date helpers to its latest `minimumReleaseAge`-gated version.

## Versions
- `chrono-node` `2.9.1` → `2.10.1`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 788 tests, 100% coverage
- [x] Date-parsing spot-check against the built bundle (see below)

## Notes
**Pin style preserved.** `chrono-node` is the only dependency in the manifest pinned exactly rather than with a caret range, so this was installed with `pnpm add --save-exact`. A plain `pnpm add` would have silently rewritten it to `^2.10.1`. The diff is one line, `"2.9.1"` → `"2.10.1"`, still caret-free.

**Parse-path spot-check.** `src/helpers/date.ts` routes string input through `parseDate()` before handing off to dayjs, so I exercised that path against `dist/index.node.mjs` — all four forms still resolve identically:

| Input | `{{date d "YYYY-MM-DD"}}` |
|---|---|
| `2026-03-15` | `2026-03-15` |
| `March 15, 2026` | `2026-03-15` |
| `15 March 2026` | `2026-03-15` |
| `2026-03-15T10:30:00Z` | `2026-03-15` |

Relative parsing is also intact (reference date `2026-03-10`): `tomorrow` → `2026-03-11`, `next friday` → `2026-03-20`, `in 3 days` → `2026-03-13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_