### PR TITLE
release: v4.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jaredwray/fumanchu",
   "description": "Handlebars + Helpers = Fumanchu",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "packageManager": "pnpm@11.15.1",
   "homepage": "https://github.com/jaredwray/fumanchu",
   "author": "Jared Wray (me@jaredwray.com)",


### PR DESCRIPTION
## Release summary
Maintenance release: refreshes runtime dependencies and the dev/CI toolchain. Bumps `@jaredwray/fumanchu` `4.7.1` → `4.7.2` (patch).

## @jaredwray/fumanchu@4.7.2 — 2026-07-24

Maintenance release: refreshes runtime dependencies and the dev/CI toolchain.

### Bug Fixes
- Allow wrangler build scripts and set the Cloudflare account ID in the site deploy workflow (69ef29e, #234)

### Documentation
- Add an external-link icon to the GitHub header nav link (31b0774, #235)

### Internal
- Upgrade runtime dependencies: `markdown-it` 14.2.0 → 14.3.0 (221f88b, #241), `@cacheable/memory` 2.0.9 → 2.2.0 (1ff0704, #242), `chrono-node` 2.9.1 → 2.10.1 (4df6b63, #243).
- Upgrade dev/build tooling: code-quality dependencies (c4847a0, #236), TypeScript and build tooling (5ba8654, #237), `docula` 2.1.0 → 2.2.0 (3425f44, #238).
- Upgrade `pnpm` 11.9.0 → 11.15.1 via `packageManager` (f1eb7e9, #239).
- Upgrade `actions/setup-node` v6 → v7 (66d33fa, #240). CI-only; no consumer impact.

### Contributors
- @jaredwray (10)

### Full List of Changes
- fix(deploy-site): allow wrangler build scripts and set Cloudflare account ID by @jaredwray in #234
- docs: add external-link icon to GitHub header nav link by @jaredwray in #235
- root - chore: upgrade code quality dependencies by @jaredwray in #236
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #237
- root - chore: upgrade docula by @jaredwray in #238
- root - chore: upgrade pnpm by @jaredwray in #239
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #240
- root - chore: upgrade markdown-it by @jaredwray in #241
- root - chore: upgrade @cacheable/memory by @jaredwray in #242
- root - chore: upgrade chrono-node by @jaredwray in #243

**Full diff:** https://github.com/jaredwray/fumanchu/compare/v4.7.1...v4.7.2

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 788 tests, 100% coverage
- [x] No uncommitted changes outside the version bump

## Notes
- Patch bump: no `feat:` commits and no breaking changes to the package's public API. The release is warranted because three **runtime** dependencies moved and therefore reach consumers; everything else is dev tooling, CI, or docs-site only.
- #240's title carries `(breaking)`, which refers to the `actions/setup-node` v6 → v7 major bump in CI. That is not a breaking change to fumanchu.
- No `CHANGELOG.md` exists in this repo, so the notes above are the canonical release notes — copy them into the GitHub Release body verbatim.
- Branch name is `claude/fumanchu-dependency-maintenance-qviktq` rather than the usual `release/v4.7.2` because this session is pinned to a designated branch.

## Post-merge
Merge, then create a GitHub Release at tag `v4.7.2` — `release.yml` triggers on the `released` event and publishes to npm via OIDC trusted publishing with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpkok3y93fu6iGtbwXyiKi)_